### PR TITLE
Fix r10k segfault by defaulting pool_size to 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "openvox-webui"
-version = "0.27.15"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "argon2",

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -176,6 +176,7 @@ rbac:
 #   r10k_binary_path: "/opt/puppetlabs/puppet/bin/r10k"
 #   r10k_config_path: "/etc/puppetlabs/r10k/r10k.yaml"
 #   r10k_cachedir: "/opt/puppetlabs/puppet/cache/r10k"
+#   r10k_pool_size: 1  # Thread pool size for r10k module installs (1 = workaround for Ruby 3.2 chown segfault)
 #   environments_basedir: "/etc/puppetlabs/code/environments"
 
 # SAML 2.0 Single Sign-On configuration

--- a/puppet/CHANGELOG.md
+++ b/puppet/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- r10k deployments now default to `pool_size: 1` to work around Ruby 3.2 segfault in `File.chown` under multithreaded execution
+  - New `r10k_pool_size` config option and `code_deploy_r10k_pool_size` Puppet parameter
+  - Also passes `--pool-size` on the r10k CLI and includes `pool_size` in generated `r10k.yaml`
+
 ### Added
 - Phase 10.2 Puppet-side inventory collectors for Linux, Windows, and macOS with package/application, website, and runtime discovery
 - `openvox_inventory_status` fact for inventory collection status and submission summary

--- a/puppet/manifests/config.pp
+++ b/puppet/manifests/config.pp
@@ -143,6 +143,7 @@ class openvox_webui::config {
         code_deploy_repos_base_dir     => $openvox_webui::code_deploy_repos_base_dir,
         code_deploy_ssh_keys_dir       => $openvox_webui::code_deploy_ssh_keys_dir,
         code_deploy_r10k_path          => $openvox_webui::code_deploy_r10k_path,
+        code_deploy_r10k_pool_size     => $openvox_webui::code_deploy_r10k_pool_size,
         code_deploy_encryption_key     => $openvox_webui::code_deploy_encryption_key,
         # Backup settings
         backup_enabled                 => $openvox_webui::backup_enabled,

--- a/puppet/manifests/init.pp
+++ b/puppet/manifests/init.pp
@@ -434,6 +434,7 @@ class openvox_webui (
   Stdlib::Absolutepath                $code_deploy_repos_base_dir      = '/var/lib/openvox-webui/code-deploy/repos',
   Stdlib::Absolutepath                $code_deploy_ssh_keys_dir        = '/etc/openvox-webui/code-deploy/ssh-keys',
   Stdlib::Absolutepath                $code_deploy_r10k_path           = '/opt/puppetlabs/puppet/bin/r10k',
+  Integer[1]                          $code_deploy_r10k_pool_size      = 1,
   String[32]                          $code_deploy_encryption_key      = fqdn_rand_string(64),
 
   # Backup settings

--- a/puppet/templates/config.yaml.epp
+++ b/puppet/templates/config.yaml.epp
@@ -58,6 +58,7 @@
   Stdlib::Absolutepath $code_deploy_repos_base_dir,
   Stdlib::Absolutepath $code_deploy_ssh_keys_dir,
   Stdlib::Absolutepath $code_deploy_r10k_path,
+  Integer $code_deploy_r10k_pool_size,
   String $code_deploy_encryption_key,
   # Backup parameters
   Boolean $backup_enabled,
@@ -270,6 +271,7 @@ code_deploy:
   repos_base_dir: "<%= $code_deploy_repos_base_dir %>"
   ssh_keys_dir: "<%= $code_deploy_ssh_keys_dir %>"
   r10k_path: "<%= $code_deploy_r10k_path %>"
+  r10k_pool_size: <%= $code_deploy_r10k_pool_size %>
   encryption_key: "<%= $code_deploy_encryption_key %>"
 <% } else { -%>
 # Code Deploy - Git-based environment management (disabled)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -719,6 +719,9 @@ pub struct CodeDeployYamlConfig {
     /// r10k cache directory
     #[serde(default = "default_r10k_cachedir")]
     pub r10k_cachedir: PathBuf,
+    /// r10k thread pool size (default: 1 to avoid Ruby 3.2 threading segfault)
+    #[serde(default = "default_r10k_pool_size")]
+    pub r10k_pool_size: u32,
     /// Encryption key for SSH private keys (should come from secure storage)
     #[serde(default)]
     pub encryption_key: String,
@@ -754,6 +757,10 @@ fn default_r10k_cachedir() -> PathBuf {
     PathBuf::from("/opt/puppetlabs/puppet/cache/r10k")
 }
 
+fn default_r10k_pool_size() -> u32 {
+    1
+}
+
 fn default_retain_history_days() -> u32 {
     90
 }
@@ -768,6 +775,7 @@ impl Default for CodeDeployYamlConfig {
             r10k_config_path: default_r10k_config_path(),
             environments_basedir: default_environments_basedir(),
             r10k_cachedir: default_r10k_cachedir(),
+            r10k_pool_size: default_r10k_pool_size(),
             encryption_key: String::new(),
             webhook_base_url: None,
             retain_history_days: default_retain_history_days(),
@@ -1651,6 +1659,13 @@ impl AppConfig {
         if let Ok(dir) = std::env::var("CODE_DEPLOY_R10K_CACHEDIR") {
             if let Some(ref mut code_deploy) = self.code_deploy {
                 code_deploy.r10k_cachedir = PathBuf::from(dir);
+            }
+        }
+        if let Ok(val) = std::env::var("CODE_DEPLOY_R10K_POOL_SIZE") {
+            if let Ok(n) = val.parse() {
+                if let Some(ref mut code_deploy) = self.code_deploy {
+                    code_deploy.r10k_pool_size = n;
+                }
             }
         }
         if let Ok(days) = std::env::var("CODE_DEPLOY_RETAIN_HISTORY_DAYS") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,6 +121,7 @@ async fn main() -> Result<()> {
                     config_path: cd.r10k_config_path.clone(),
                     basedir: cd.environments_basedir.clone(),
                     cachedir: cd.r10k_cachedir.clone(),
+                    pool_size: cd.r10k_pool_size,
                     ..Default::default()
                 },
                 enabled: true,

--- a/src/services/r10k.rs
+++ b/src/services/r10k.rs
@@ -49,6 +49,14 @@ pub struct R10kConfig {
     /// Extra arguments to pass to r10k
     #[serde(default)]
     pub extra_args: Vec<String>,
+    /// r10k thread pool size for module installations (default: 1)
+    /// Set to 1 to work around Ruby 3.2 segfault in File.chown under multithreading
+    #[serde(default = "default_pool_size")]
+    pub pool_size: u32,
+}
+
+fn default_pool_size() -> u32 {
+    1
 }
 
 fn default_binary_path() -> PathBuf {
@@ -86,6 +94,7 @@ impl Default for R10kConfig {
             deploy_puppetfile: default_deploy_puppetfile(),
             generate_types: false,
             extra_args: vec![],
+            pool_size: default_pool_size(),
         }
     }
 }
@@ -220,6 +229,11 @@ impl R10kService {
         // Add verbose output for logging
         args.push("-v");
 
+        // Add pool size to avoid Ruby threading segfault
+        let pool_size_str = self.config.pool_size.to_string();
+        args.push("--pool-size");
+        args.push(&pool_size_str);
+
         // Add extra args
         for arg in &self.config.extra_args {
             args.push(arg);
@@ -283,6 +297,11 @@ impl R10kService {
         args.push("-c");
         args.push(self.config.config_path.to_str().unwrap_or("/etc/puppetlabs/r10k/r10k.yaml"));
         args.push("-v");
+
+        // Add pool size to avoid Ruby threading segfault
+        let pool_size_str = self.config.pool_size.to_string();
+        args.push("--pool-size");
+        args.push(&pool_size_str);
 
         for arg in &self.config.extra_args {
             args.push(arg);
@@ -544,6 +563,7 @@ impl R10kService {
                 .iter()
                 .map(|s| (s.name.clone(), s.clone()))
                 .collect(),
+            pool_size: Some(self.config.pool_size),
             deploy: Some(R10kDeploySettings {
                 purge_levels: Some(vec!["deployment".to_string()]),
                 purge_allowlist: None,
@@ -624,6 +644,8 @@ pub struct R10kSource {
 struct R10kYamlConfig {
     cachedir: String,
     sources: std::collections::HashMap<String, R10kSource>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pool_size: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     deploy: Option<R10kDeploySettings>,
 }


### PR DESCRIPTION
## Summary
- r10k crashes with `SIGSEGV` in Ruby 3.2's `File.chown` (`rb_file_s_chown`) when running with multiple threads (default `pool_size: 6`)
- Adds `r10k_pool_size` config option (default `1`) across the full stack: Rust config, CLI args (`--pool-size`), generated `r10k.yaml`, Puppet module parameter, and EPP template
- This avoids the multithreaded chown race condition; users can increase the value once Ruby is upgraded

## Test plan
- [x] `cargo check` compiles cleanly
- [x] `cargo test --lib` — all 247 tests pass
- [x] `cargo test --lib services::r10k` — all 4 r10k-specific tests pass
- [ ] Deploy to staging and verify r10k runs without segfault
- [ ] Verify generated `r10k.yaml` includes `pool_size: 1`
- [ ] Verify r10k CLI args include `--pool-size 1` in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)