### PR TITLE
Remove invalid --pool-size CLI argument from r10k

### DIFF
--- a/puppet/CHANGELOG.md
+++ b/puppet/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - r10k deployments now default to `pool_size: 1` to work around Ruby 3.2 segfault in `File.chown` under multithreaded execution
   - New `r10k_pool_size` config option and `code_deploy_r10k_pool_size` Puppet parameter
-  - Also passes `--pool-size` on the r10k CLI and includes `pool_size` in generated `r10k.yaml`
+  - Includes `pool_size` in generated `r10k.yaml`
+- Removed invalid `--pool-size` CLI argument from r10k invocations (not a valid r10k CLI option)
 
 ### Added
 - Phase 10.2 Puppet-side inventory collectors for Linux, Windows, and macOS with package/application, website, and runtime discovery

--- a/src/services/r10k.rs
+++ b/src/services/r10k.rs
@@ -229,11 +229,6 @@ impl R10kService {
         // Add verbose output for logging
         args.push("-v");
 
-        // Add pool size to avoid Ruby threading segfault
-        let pool_size_str = self.config.pool_size.to_string();
-        args.push("--pool-size");
-        args.push(&pool_size_str);
-
         // Add extra args
         for arg in &self.config.extra_args {
             args.push(arg);
@@ -297,11 +292,6 @@ impl R10kService {
         args.push("-c");
         args.push(self.config.config_path.to_str().unwrap_or("/etc/puppetlabs/r10k/r10k.yaml"));
         args.push("-v");
-
-        // Add pool size to avoid Ruby threading segfault
-        let pool_size_str = self.config.pool_size.to_string();
-        args.push("--pool-size");
-        args.push(&pool_size_str);
 
         for arg in &self.config.extra_args {
             args.push(arg);


### PR DESCRIPTION
## Summary
- Removed `--pool-size` CLI argument from `deploy_environment_with_tracking()` and `deploy_all()` in `r10k.rs`
- r10k 5.0.2 does not support `--pool-size` as a CLI flag, causing `unrecognised option` errors
- The `pool_size` setting is already correctly written to the generated `r10k.yaml` config file, which is the proper way to configure it

## Test plan
- [ ] Verify `cargo check` and `cargo test` pass
- [ ] Deploy to a server running r10k 5.0.2 and confirm deployments no longer error with "unrecognised option -- pool-size"
- [ ] Confirm `pool_size` is still present in generated `r10k.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)