### PR TITLE
Fix intermittent r10k deployment corruption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "openvox-webui"
-version = "0.28.0"
+version = "0.28.3"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openvox-webui"
-version = "0.28.2"
+version = "0.28.3"
 edition = "2021"
 authors = ["OpenVox Contributors"]
 description = "Web interface for OpenVox infrastructure management"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openvox-webui-frontend",
-  "version": "0.28.2",
+  "version": "0.28.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/puppet/CHANGELOG.md
+++ b/puppet/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - New `r10k_pool_size` config option and `code_deploy_r10k_pool_size` Puppet parameter
   - Includes `pool_size` in generated `r10k.yaml`
 - Removed invalid `--pool-size` CLI argument from r10k invocations (not a valid r10k CLI option)
+- Fixed intermittent r10k deployment corruption leaving partial modules (e.g., only CHANGELOG.md)
+  - Timeout now sends SIGTERM (graceful) before escalating to SIGKILL after 30s, preventing mid-file-write kills
+  - Signal-terminated r10k processes are no longer falsely marked as "successful"
+  - Set explicit working directory (`/tmp`) for spawned r10k process to prevent Ruby `getcwd` errors
+  - Added `purge_allowlist` to generated `r10k.yaml` to protect deployment marker files
 
 ### Added
 - Phase 10.2 Puppet-side inventory collectors for Linux, Windows, and macOS with package/application, website, and runtime discovery

--- a/puppet/metadata.json
+++ b/puppet/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ffquintella-openvox_webui",
-  "version": "0.28.2",
+  "version": "0.28.3",
   "author": "ffquintella",
   "license": "Apache-2.0",
   "summary": "Puppet module for installing and configuring OpenVox WebUI",

--- a/src/services/r10k.rs
+++ b/src/services/r10k.rs
@@ -382,7 +382,8 @@ impl R10kService {
         let mut cmd = Command::new(&self.config.binary_path);
         cmd.args(args)
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
+            .stderr(Stdio::piped())
+            .current_dir("/tmp"); // Use stable CWD that won't be purged during r10k deployment
 
         let mut child = cmd.spawn().context("Failed to spawn r10k process")?;
 
@@ -462,21 +463,16 @@ impl R10kService {
                 let success = if exit_status.success() {
                     true
                 } else if signal.is_some() {
-                    // Process was killed by a signal - check if it actually completed successfully
-                    // by looking for successful deployment indicators in the output
-                    let output_indicates_success = stderr_str.contains("Deploying module to")
-                        || stderr_str.contains("Environment")
-                        || stdout_str.contains("Deploying module to");
-
-                    if output_indicates_success {
-                        warn!(
-                            "r10k was terminated by signal {:?} but output indicates successful completion",
-                            signal
-                        );
-                        true
-                    } else {
-                        false
-                    }
+                    // Signal-terminated r10k is NEVER considered successful.
+                    // Previous logic checked for "Deploying module to" in output, but that
+                    // string appears early in deployment before files are fully written.
+                    // Marking a killed deployment as "successful" causes corruption to persist
+                    // because no retry is triggered and partial files are left on disk.
+                    warn!(
+                        "r10k was terminated by signal {:?} - marking as FAILED (partial deployment may have occurred)",
+                        signal
+                    );
+                    false
                 } else {
                     false
                 };
@@ -521,12 +517,54 @@ impl R10kService {
             }
             Err(_) => {
                 cleanup().await;
-                // Timeout - kill the process
+                // Timeout - gracefully terminate the process with SIGTERM first,
+                // then escalate to SIGKILL if it doesn't exit within 30 seconds.
+                // Using SIGKILL immediately can corrupt module directories by killing
+                // r10k mid-file-write, leaving partial modules (e.g., only CHANGELOG.md).
                 error!(
                     "r10k command TIMEOUT after {}s: command='{}'",
                     self.config.timeout_seconds, command_str
                 );
-                let _ = child.kill().await;
+
+                #[cfg(unix)]
+                {
+                    if let Some(pid) = child.id() {
+                        info!("Sending SIGTERM to r10k process (pid={})", pid);
+                        let term_result = unsafe { libc::kill(pid as i32, libc::SIGTERM) };
+                        if term_result == 0 {
+                            // Wait up to 30 seconds for graceful exit
+                            match timeout(Duration::from_secs(30), child.wait()).await {
+                                Ok(Ok(status)) => {
+                                    info!(
+                                        "r10k exited gracefully after SIGTERM (status={:?})",
+                                        status.code()
+                                    );
+                                }
+                                Ok(Err(e)) => {
+                                    warn!("Error waiting for r10k after SIGTERM: {}", e);
+                                    let _ = child.kill().await;
+                                }
+                                Err(_) => {
+                                    warn!("r10k did not exit within 30s after SIGTERM, sending SIGKILL");
+                                    let _ = child.kill().await;
+                                }
+                            }
+                        } else {
+                            warn!(
+                                "Failed to send SIGTERM to r10k (pid={}), sending SIGKILL",
+                                pid
+                            );
+                            let _ = child.kill().await;
+                        }
+                    } else {
+                        let _ = child.kill().await;
+                    }
+                }
+
+                #[cfg(not(unix))]
+                {
+                    let _ = child.kill().await;
+                }
 
                 Ok(DeploymentResult {
                     success: false,
@@ -556,7 +594,9 @@ impl R10kService {
             pool_size: Some(self.config.pool_size),
             deploy: Some(R10kDeploySettings {
                 purge_levels: Some(vec!["deployment".to_string()]),
-                purge_allowlist: None,
+                purge_allowlist: Some(vec![
+                    ".r10k-deploy.json".to_string(),
+                ]),
             }),
         };
 


### PR DESCRIPTION
## Summary

- **Graceful timeout handling**: r10k timeout now sends SIGTERM first (30s grace period) before escalating to SIGKILL, preventing mid-file-write kills that left partial modules (e.g., only CHANGELOG.md)
- **Removed false success detection**: Signal-terminated r10k processes are always marked as FAILED — previous logic falsely marked killed deploys as "successful" based on early-appearing log strings like "Deploying module to", preventing retries
- **Stable working directory**: Set explicit `current_dir(/tmp)` on spawned r10k process to prevent Ruby `getcwd` errors when `purge_levels: ["deployment"]` deletes/recreates environment directories
- **Purge protection**: Added `purge_allowlist` to generated `r10k.yaml` to protect `.r10k-deploy.json` marker files

## Root Cause

When r10k deployments took longer than the 600s timeout, `child.kill()` sent SIGKILL immediately. r10k was killed mid-file-write, leaving modules with only the first few files written (e.g., CHANGELOG.md). The corruption persisted because the false success detection marked these killed deploys as "successful", so no retry was triggered.

## Test plan

- [ ] `cargo check` passes
- [ ] Trigger code deploy from openvox-webui UI — verify all module files present
- [ ] Set short timeout (e.g., 5s) — verify deployment fails cleanly without corruption
- [ ] Cancel a running deployment — verify modules not left in partial state
- [ ] Check `journalctl -u openvox-webui` for SIGTERM/SIGKILL log messages on timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)