### PR TITLE
Fix inventory limits, update job dispatch, and version catalog

### DIFF
--- a/frontend/src/pages/NodeDetail.tsx
+++ b/frontend/src/pages/NodeDetail.tsx
@@ -936,6 +936,8 @@ function InventorySection({
   const [applicationTypeFilter, setApplicationTypeFilter] = useState<string>('all');
   const [websiteTypeFilter, setWebsiteTypeFilter] = useState<string>('all');
   const [runtimeTypeFilter, setRuntimeTypeFilter] = useState<string>('all');
+  const [packageDisplayCount, setPackageDisplayCount] = useState(100);
+  const [applicationDisplayCount, setApplicationDisplayCount] = useState(100);
 
   const packageRepos = useMemo(
     () => ['all', ...new Set(inventory.packages.map((pkg) => pkg.repository_source).filter(Boolean) as string[])],
@@ -1013,6 +1015,11 @@ function InventorySection({
       }),
     [inventory.runtimes, runtimeTypeFilter, searchQuery],
   );
+
+  useEffect(() => {
+    setPackageDisplayCount(100);
+    setApplicationDisplayCount(100);
+  }, [searchQuery, packageRepoFilter, applicationTypeFilter]);
 
   const filteredHistory = useMemo(
     () =>
@@ -1240,29 +1247,39 @@ function InventorySection({
               {filteredPackages.length === 0 ? (
                 <div className="p-6 text-sm text-gray-500 text-center">No packages reported.</div>
               ) : (
-                filteredPackages.slice(0, 250).map((pkg) => (
-                  <div key={`${pkg.name}-${pkg.version}-${pkg.release ?? 'na'}`} className="p-3">
-                    <div className="flex items-start justify-between gap-3">
-                      <div>
-                        <p className="text-sm font-medium text-gray-900">{pkg.name}</p>
-                        <p className="text-xs text-gray-500">
-                          {renderInventoryVersion(pkg.version, pkg.release)}
-                          {pkg.architecture ? ` • ${pkg.architecture}` : ''}
-                        </p>
-                        {pkg.install_time && (
-                          <p className="text-xs text-gray-400 mt-1">
-                            Installed {new Date(pkg.install_time).toLocaleString()}
+                <>
+                  {filteredPackages.slice(0, packageDisplayCount).map((pkg) => (
+                    <div key={`${pkg.name}-${pkg.version}-${pkg.release ?? 'na'}`} className="p-3">
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <p className="text-sm font-medium text-gray-900">{pkg.name}</p>
+                          <p className="text-xs text-gray-500">
+                            {renderInventoryVersion(pkg.version, pkg.release)}
+                            {pkg.architecture ? ` • ${pkg.architecture}` : ''}
                           </p>
+                          {pkg.install_time && (
+                            <p className="text-xs text-gray-400 mt-1">
+                              Installed {new Date(pkg.install_time).toLocaleString()}
+                            </p>
+                          )}
+                        </div>
+                        {pkg.repository_source && (
+                          <span className="text-xs px-2 py-1 rounded-full bg-gray-100 text-gray-600">
+                            {pkg.repository_source}
+                          </span>
                         )}
                       </div>
-                      {pkg.repository_source && (
-                        <span className="text-xs px-2 py-1 rounded-full bg-gray-100 text-gray-600">
-                          {pkg.repository_source}
-                        </span>
-                      )}
                     </div>
-                  </div>
-                ))
+                  ))}
+                  {filteredPackages.length > packageDisplayCount && (
+                    <button
+                      onClick={() => setPackageDisplayCount(prev => prev + 100)}
+                      className="w-full p-3 text-sm text-blue-600 hover:bg-gray-50 font-medium border-t border-gray-100"
+                    >
+                      Show more ({filteredPackages.length - packageDisplayCount} remaining)
+                    </button>
+                  )}
+                </>
               )}
             </div>
           </div>
@@ -1278,32 +1295,42 @@ function InventorySection({
               {filteredApplications.length === 0 ? (
                 <div className="p-6 text-sm text-gray-500 text-center">No applications reported.</div>
               ) : (
-                filteredApplications.slice(0, 250).map((app) => (
-                  <div key={`${app.name}-${app.version}-${app.install_path ?? 'na'}`} className="p-3">
-                    <div className="flex items-start justify-between gap-3">
-                      <div>
-                        <p className="text-sm font-medium text-gray-900">{app.name}</p>
-                        <p className="text-xs text-gray-500">
-                          {app.version}
-                          {app.publisher ? ` • ${app.publisher}` : ''}
-                        </p>
-                        <p className="text-xs text-gray-400 mt-1">
-                          {[app.install_scope, app.architecture].filter(Boolean).join(' • ') || 'Scope unknown'}
-                        </p>
-                        {app.install_path && (
-                          <p className="text-xs text-gray-400 mt-1 font-mono break-all">
-                            {app.install_path}
+                <>
+                  {filteredApplications.slice(0, applicationDisplayCount).map((app) => (
+                    <div key={`${app.name}-${app.version}-${app.install_path ?? 'na'}`} className="p-3">
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <p className="text-sm font-medium text-gray-900">{app.name}</p>
+                          <p className="text-xs text-gray-500">
+                            {app.version}
+                            {app.publisher ? ` • ${app.publisher}` : ''}
                           </p>
+                          <p className="text-xs text-gray-400 mt-1">
+                            {[app.install_scope, app.architecture].filter(Boolean).join(' • ') || 'Scope unknown'}
+                          </p>
+                          {app.install_path && (
+                            <p className="text-xs text-gray-400 mt-1 font-mono break-all">
+                              {app.install_path}
+                            </p>
+                          )}
+                        </div>
+                        {app.application_type && (
+                          <span className="text-xs px-2 py-1 rounded-full bg-primary-50 text-primary-700">
+                            {app.application_type}
+                          </span>
                         )}
                       </div>
-                      {app.application_type && (
-                        <span className="text-xs px-2 py-1 rounded-full bg-primary-50 text-primary-700">
-                          {app.application_type}
-                        </span>
-                      )}
                     </div>
-                  </div>
-                ))
+                  ))}
+                  {filteredApplications.length > applicationDisplayCount && (
+                    <button
+                      onClick={() => setApplicationDisplayCount(prev => prev + 100)}
+                      className="w-full p-3 text-sm text-blue-600 hover:bg-gray-50 font-medium border-t border-gray-100"
+                    >
+                      Show more ({filteredApplications.length - applicationDisplayCount} remaining)
+                    </button>
+                  )}
+                </>
               )}
             </div>
           </div>

--- a/puppet/CHANGELOG.md
+++ b/puppet/CHANGELOG.md
@@ -15,6 +15,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Inventory client now polls for and executes pending update jobs (system patch, security patch, package operations)
+- Version catalog and update statuses now refresh automatically after inventory submission
+
+### Fixed
+- Inventory now collects all packages instead of capping at 500 items per category (default raised to 10,000)
+- Removed frontend display cap of 250 items for packages and applications; now uses progressive loading
+- Update jobs no longer stay stuck in "queued" status — client executes them on next Puppet run
+- Version catalog now populates without requiring `inventory.enabled: true` in server config
+
+### Changed
+- `inventory_max_items` parameter default raised from 500 to 10,000 (upper bound from 5,000 to 50,000)
+
 ### Fixed
 - r10k deployments now default to `pool_size: 1` to work around Ruby 3.2 segfault in `File.chown` under multithreaded execution
   - New `r10k_pool_size` config option and `code_deploy_r10k_pool_size` Puppet parameter

--- a/puppet/lib/facter/openvox_inventory.rb
+++ b/puppet/lib/facter/openvox_inventory.rb
@@ -6,6 +6,7 @@ require 'net/http'
 require 'openssl'
 require 'time'
 require 'uri'
+require 'shellwords'
 require 'yaml'
 
 module OpenVoxInventory
@@ -630,8 +631,172 @@ module OpenVoxInventory
     request['X-Classification-Key'] = classification_key if classification_key
   end
 
+  def fetch_pending_update_jobs(config, certname)
+    api_url = config['api_url'] || config['url']
+    return [] if api_url.nil? || certname.nil?
+
+    uri = URI.parse("#{api_url.chomp('/')}/api/v1/nodes/#{certname}/update-jobs")
+    http = build_http(uri, config, certname)
+
+    request = Net::HTTP::Get.new(uri.request_uri)
+    request['Accept'] = 'application/json'
+    request['User-Agent'] = 'OpenVox-InventoryCollector/1.0'
+    add_auth_headers(request, config)
+
+    response = http.request(request)
+    return [] unless response.code.to_i >= 200 && response.code.to_i < 300
+
+    JSON.parse(response.body)
+  rescue StandardError => e
+    Facter.warn("openvox_inventory: Failed to fetch pending update jobs: #{e.message}")
+    []
+  end
+
+  def execute_update_job(job, config)
+    os_fact = Facter.value(:os) || {}
+    family = os_fact.dig('family') || Facter.value(:kernel)
+    operation = job['operation_type']
+    packages = job['package_names'] || []
+
+    case operation
+    when 'system_patch', 'SystemPatch'
+      execute_system_patch(family, config)
+    when 'security_patch', 'SecurityPatch'
+      execute_security_patch(family, config)
+    when 'package_update', 'PackageUpdate'
+      execute_package_update(family, packages, config)
+    when 'package_install', 'PackageInstall'
+      execute_package_install(family, packages, config)
+    when 'package_remove', 'PackageRemove'
+      execute_package_remove(family, packages, config)
+    else
+      { 'status' => 'failed', 'summary' => "Unknown operation type: #{operation}", 'output' => '' }
+    end
+  end
+
+  def execute_system_patch(family, _config)
+    cmd = case family
+          when 'RedHat', 'Suse'
+            'dnf update -y 2>&1 || yum update -y 2>&1'
+          when 'Debian'
+            'apt-get update -q && apt-get upgrade -y 2>&1'
+          else
+            return { 'status' => 'failed', 'summary' => "Unsupported OS family: #{family}", 'output' => '' }
+          end
+
+    run_update_command(cmd)
+  end
+
+  def execute_security_patch(family, _config)
+    cmd = case family
+          when 'RedHat', 'Suse'
+            'dnf update --security -y 2>&1 || yum update --security -y 2>&1'
+          when 'Debian'
+            'apt-get update -q && apt-get upgrade -y --only-upgrade 2>&1'
+          else
+            return { 'status' => 'failed', 'summary' => "Unsupported OS family: #{family}", 'output' => '' }
+          end
+
+    run_update_command(cmd)
+  end
+
+  def sanitize_package_names(packages)
+    packages.select { |p| p.is_a?(String) && p.match?(/\A[a-zA-Z0-9._+\-:]+\z/) }
+  end
+
+  def execute_package_update(family, packages, _config)
+    safe_packages = sanitize_package_names(packages)
+    return { 'status' => 'failed', 'summary' => 'No valid packages specified', 'output' => '' } if safe_packages.empty?
+
+    pkg_list = safe_packages.map { |p| Shellwords.shellescape(p) }.join(' ')
+    cmd = case family
+          when 'RedHat', 'Suse'
+            "dnf update -y #{pkg_list} 2>&1 || yum update -y #{pkg_list} 2>&1"
+          when 'Debian'
+            "apt-get update -q && apt-get install --only-upgrade -y #{pkg_list} 2>&1"
+          else
+            return { 'status' => 'failed', 'summary' => "Unsupported OS family: #{family}", 'output' => '' }
+          end
+
+    run_update_command(cmd)
+  end
+
+  def execute_package_install(family, packages, _config)
+    safe_packages = sanitize_package_names(packages)
+    return { 'status' => 'failed', 'summary' => 'No valid packages specified', 'output' => '' } if safe_packages.empty?
+
+    pkg_list = safe_packages.map { |p| Shellwords.shellescape(p) }.join(' ')
+    cmd = case family
+          when 'RedHat', 'Suse'
+            "dnf install -y #{pkg_list} 2>&1 || yum install -y #{pkg_list} 2>&1"
+          when 'Debian'
+            "apt-get update -q && apt-get install -y #{pkg_list} 2>&1"
+          else
+            return { 'status' => 'failed', 'summary' => "Unsupported OS family: #{family}", 'output' => '' }
+          end
+
+    run_update_command(cmd)
+  end
+
+  def execute_package_remove(family, packages, _config)
+    safe_packages = sanitize_package_names(packages)
+    return { 'status' => 'failed', 'summary' => 'No valid packages specified', 'output' => '' } if safe_packages.empty?
+
+    pkg_list = safe_packages.map { |p| Shellwords.shellescape(p) }.join(' ')
+    cmd = case family
+          when 'RedHat', 'Suse'
+            "dnf remove -y #{pkg_list} 2>&1 || yum remove -y #{pkg_list} 2>&1"
+          when 'Debian'
+            "apt-get remove -y #{pkg_list} 2>&1"
+          else
+            return { 'status' => 'failed', 'summary' => "Unsupported OS family: #{family}", 'output' => '' }
+          end
+
+    run_update_command(cmd)
+  end
+
+  def run_update_command(cmd)
+    output = `#{cmd}`
+    exit_code = $CHILD_STATUS.exitstatus
+    {
+      'status' => exit_code == 0 ? 'succeeded' : 'failed',
+      'summary' => exit_code == 0 ? 'Update completed successfully' : "Update failed with exit code #{exit_code}",
+      'output' => output.to_s.slice(0, 10_000)
+    }
+  rescue StandardError => e
+    { 'status' => 'failed', 'summary' => "Execution error: #{e.message}", 'output' => '' }
+  end
+
+  def submit_update_job_result(config, certname, job_id, target_id, result, started_at, finished_at)
+    api_url = config['api_url'] || config['url']
+    return unless api_url
+
+    uri = URI.parse("#{api_url.chomp('/')}/api/v1/nodes/#{certname}/update-jobs/#{job_id}/targets/#{target_id}/results")
+    http = build_http(uri, config, certname)
+
+    request = Net::HTTP::Post.new(uri.request_uri)
+    request['Accept'] = 'application/json'
+    request['Content-Type'] = 'application/json'
+    request['User-Agent'] = 'OpenVox-InventoryCollector/1.0'
+    add_auth_headers(request, config)
+
+    payload = {
+      'status' => result['status'],
+      'summary' => result['summary'],
+      'output' => result['output'],
+      'started_at' => started_at,
+      'finished_at' => finished_at
+    }
+    request.body = JSON.generate(payload)
+
+    response = http.request(request)
+    Facter.warn("openvox_inventory: Update job result submission returned #{response.code}") unless response.code.to_i < 300
+  rescue StandardError => e
+    Facter.warn("openvox_inventory: Failed to submit update job result: #{e.message}")
+  end
+
   def trim(items, config)
-    max_items = (config['inventory_max_items'] || 500).to_i
+    max_items = (config['inventory_max_items'] || 10000).to_i
     items.first(max_items)
   end
 
@@ -764,6 +929,21 @@ Facter.add(:openvox_inventory_status) do
       submitted, status_code = OpenVoxInventory.submit_inventory(config, certname, payload)
     end
 
+    # Poll for and execute pending update jobs
+    update_jobs_executed = 0
+    if submitted && config['inventory_updates'] != false
+      pending_jobs = OpenVoxInventory.fetch_pending_update_jobs(config, certname)
+      pending_jobs.each do |job|
+        started_at = Time.now.utc.iso8601
+        result = OpenVoxInventory.execute_update_job(job, config)
+        finished_at = Time.now.utc.iso8601
+        OpenVoxInventory.submit_update_job_result(
+          config, certname, job['job_id'], job['target_id'], result, started_at, finished_at
+        )
+        update_jobs_executed += 1
+      end
+    end
+
     {
       'certname' => certname,
       'collector_version' => payload['collector_version'],
@@ -776,7 +956,8 @@ Facter.add(:openvox_inventory_status) do
       'website_count' => payload['websites'].size,
       'runtime_count' => payload['runtimes'].size,
       'submitted' => submitted,
-      'status_code' => status_code
+      'status_code' => status_code,
+      'update_jobs_executed' => update_jobs_executed
     }
   end
 end

--- a/puppet/manifests/client.pp
+++ b/puppet/manifests/client.pp
@@ -105,7 +105,7 @@ class openvox_webui::client (
   Optional[String[1]]                 $classification_key = undef,
   Boolean                             $inventory_enabled  = false,
   Boolean                             $inventory_submit   = true,
-  Integer[10, 5000]                   $inventory_max_items = 500,
+  Integer[10, 50000]                  $inventory_max_items = 10000,
 ) {
   # Validate that we have some form of authentication
   if !$use_puppet_certs and !$api_token and !$api_key and !$classification_key {

--- a/src/api/nodes.rs
+++ b/src/api/nodes.rs
@@ -656,6 +656,24 @@ async fn ingest_node_inventory(
         .await
         .map_err(|e| AppError::Internal(format!("Failed to ingest node inventory: {}", e)))?;
 
+    // Trigger background catalog and status refresh after ingestion
+    let db = state.db.clone();
+    let stale_hours = state
+        .config
+        .inventory
+        .as_ref()
+        .map(|i| i.stale_after_hours)
+        .unwrap_or(48);
+    tokio::spawn(async move {
+        let repo = InventoryRepository::new(db);
+        if let Err(e) = repo.refresh_version_catalog().await {
+            tracing::warn!("Post-ingestion catalog refresh failed: {}", e);
+        }
+        if let Err(e) = repo.refresh_host_update_statuses(stale_hours).await {
+            tracing::warn!("Post-ingestion status refresh failed: {}", e);
+        }
+    });
+
     Ok((StatusCode::CREATED, Json(inventory)))
 }
 


### PR DESCRIPTION
## Summary
- **Inventory package limit**: Raised default collection cap from 500 to 10,000 items per category in the facter plugin and Puppet parameter (was causing all hosts to show exactly 500 packages)
- **Update job dispatch**: Added client-side polling and execution of pending update jobs (system patch, security patch, package install/update/remove) to the facter plugin — jobs were stuck in "queued" forever because no client code existed to claim and run them
- **Version catalog empty**: Triggered `refresh_version_catalog()` and `refresh_host_update_statuses()` as background tasks after inventory ingestion, so the catalog populates without requiring `inventory.enabled: true` in server config
- **Frontend display cap**: Replaced hard `.slice(0, 250)` on packages/applications with progressive "Show More" loading (100 at a time)

## Test plan
- [ ] Deploy updated facter plugin to a node and verify inventory reports full package count (not capped at 500)
- [ ] Create an update job via the UI, run Puppet on the target node, and verify the job transitions from queued → dispatched → succeeded/failed
- [ ] Submit inventory from a node and verify the Version Catalog tab populates
- [ ] Verify the Inventory tab "Show More" button works for nodes with >100 packages
- [ ] Run `cargo check` and `npm run build` to verify compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)