### PR TITLE
Fix frontend build failures for RPM packaging

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openvox-webui-frontend",
-  "version": "0.29.0",
+  "version": "0.29.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openvox-webui-frontend",
-      "version": "0.29.0",
+      "version": "0.29.4",
       "dependencies": {
         "@tanstack/react-query": "^5.95.0",
         "axios": "^1.13.5",
@@ -31,7 +31,7 @@
         "@vitest/coverage-v8": "^4.0.18",
         "autoprefixer": "^10.4.24",
         "eslint": "^10.1.0",
-        "eslint-plugin-react-hooks": "7.1.0-canary-52684925-20251110",
+        "eslint-plugin-react-hooks": "7.1.0-canary-c80a0750-20260312",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
         "jsdom": "^29.0.1",
@@ -2940,9 +2940,9 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "7.1.0-canary-52684925-20251110",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.0-canary-52684925-20251110.tgz",
-      "integrity": "sha512-XiPpf+A0S7Y7CaI0fIPQBOV5bCzsMMEa/uWHdWycIvFqfpDURfGs+xkf1ebbPvLyf9eX6NLaB5k2Q8B97QStLg==",
+      "version": "7.1.0-canary-c80a0750-20260312",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.0-canary-c80a0750-20260312.tgz",
+      "integrity": "sha512-Bnil1AtJTTFMTsKYbzxRjNrf7E8cSJVeBZqiIhsNVWxfMAmwCgd9FtlPFCWiV+mCX71P7RmDMcWSQq2sdylBZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2956,7 +2956,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-react-refresh": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,7 +41,7 @@
     "@vitest/coverage-v8": "^4.0.18",
     "autoprefixer": "^10.4.24",
     "eslint": "^10.1.0",
-    "eslint-plugin-react-hooks": "7.1.0-canary-52684925-20251110",
+    "eslint-plugin-react-hooks": "7.1.0-canary-c80a0750-20260312",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
     "jsdom": "^29.0.1",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -51,12 +51,19 @@ export default defineConfig(({ mode }) => {
       sourcemap: true,
       rollupOptions: {
         output: {
-          manualChunks: {
-            // Vendor chunks - separating large dependencies
-            'vendor-react': ['react', 'react-dom', 'react-router-dom'],
-            'vendor-query': ['@tanstack/react-query'],
-            'vendor-charts': ['recharts'],
-            'vendor-ui': ['lucide-react', 'zustand'],
+          manualChunks(id) {
+            if (id.includes('node_modules/react-dom') || id.includes('node_modules/react/') || id.includes('node_modules/react-router-dom')) {
+              return 'vendor-react';
+            }
+            if (id.includes('node_modules/@tanstack/react-query')) {
+              return 'vendor-query';
+            }
+            if (id.includes('node_modules/recharts')) {
+              return 'vendor-charts';
+            }
+            if (id.includes('node_modules/lucide-react') || id.includes('node_modules/zustand')) {
+              return 'vendor-ui';
+            }
           },
         },
       },


### PR DESCRIPTION
## Changes

- **Updated frontend version** from 0.29.0 to 0.29.4
- **Updated eslint-plugin-react-hooks** to canary version with ESLint 10 support
  - Changed from `7.1.0-canary-52684925-20251110` to `7.1.0-canary-c80a0750-20260312`
  - Updated peer dependency to support ESLint 10.x
- **Refactored vite.config.ts** bundle strategy
  - Changed from object-based to function-based `manualChunks` configuration
  - This resolves build failures when packaging for RPM distribution

## Impact

These changes ensure the frontend builds successfully for RPM packaging while maintaining proper code splitting and vendor chunk separation.