### PR TITLE
fix: resolve merge conflict markers in version files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "openvox-webui"
-<<<<<<< Updated upstream
 version = "0.29.5"
-=======
-version = "0.29.3"
->>>>>>> Stashed changes
 edition = "2021"
 authors = ["OpenVox Contributors"]
 description = "Web interface for OpenVox infrastructure management"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,10 +1,6 @@
 {
   "name": "openvox-webui-frontend",
-<<<<<<< Updated upstream
   "version": "0.29.5",
-=======
-  "version": "0.29.3",
->>>>>>> Stashed changes
   "private": true,
   "type": "module",
   "scripts": {

--- a/puppet/metadata.json
+++ b/puppet/metadata.json
@@ -1,10 +1,6 @@
 {
   "name": "ffquintella-openvox_webui",
-<<<<<<< Updated upstream
   "version": "0.29.5",
-=======
-  "version": "0.29.3",
->>>>>>> Stashed changes
   "author": "ffquintella",
   "license": "Apache-2.0",
   "summary": "Puppet module for installing and configuring OpenVox WebUI",


### PR DESCRIPTION
## Changes

Resolves merge conflict markers across version files by keeping the upstream version (0.29.5):

- **Cargo.toml**: Removed conflict markers, kept version 0.29.5
- **frontend/package.json**: Removed conflict markers, kept version 0.29.5
- **puppet/metadata.json**: Removed conflict markers, kept version 0.29.5

## Summary

This PR cleans up unresolved merge conflicts in the project's version files by accepting the upstream version (0.29.5) over the stashed changes (0.29.3) across all three configuration files.