### PR TITLE
Fix r10k base64 gem dependency for Ruby 3.2

### DIFF
--- a/puppet/CHANGELOG.md
+++ b/puppet/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `winget` as default Windows package repository source
 
 ### Fixed
+- Install base64 gem for r10k compatibility with Ruby 3.2 (puppet_forge requires >= 0.2.0, but Ruby 3.2 only ships 0.1.1)
 - Fix dashboard stats grid layout: 5 status cards now fit on a single row instead of wrapping
 - Fix Activity Heatmap showing "No activity data available" — now correctly parses PuppetDB raw metrics format (`{data: [...], href: "..."}`) in addition to pre-parsed format
 - Fix outdated software "Affected Nodes" count inflated by duplicate package entries (e.g., gpg-pubkey) — now counts unique nodes per package

--- a/puppet/manifests/config.pp
+++ b/puppet/manifests/config.pp
@@ -190,6 +190,14 @@ class openvox_webui::config {
         creates => $ssh_keys_dir,
         path    => ['/bin', '/usr/bin'],
       }
+
+      # Install base64 gem for r10k compatibility
+      # Ruby 3.2 ships base64 0.1.1 as default gem, but puppet_forge 6.1.0
+      # requires base64 >= 0.2.0. Without this, r10k fails to run.
+      package { 'base64':
+        ensure   => '0.3.0',
+        provider => 'puppet_gem',
+      }
     }
 
     # Create Backup directory if enabled


### PR DESCRIPTION
## Summary
- Install `base64` 0.3.0 gem via `puppet_gem` provider when code deploy is enabled
- `puppet_forge` 6.1.0 requires `base64 >= 0.2.0`, but Ruby 3.2 only ships 0.1.1 as a default gem, causing r10k to fail with `Gem::MissingSpecError`

## Test plan
- [ ] Run `puppet apply` with `code_deploy_enabled => true` on a Puppet Server node
- [ ] Verify `/opt/puppetlabs/puppet/bin/gem list base64` shows >= 0.2.0
- [ ] Verify `/opt/puppetlabs/puppet/bin/r10k version` runs without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)