### PR TITLE
Fix inventory 422 blocking update job dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3185,7 +3185,7 @@ dependencies = [
 
 [[package]]
 name = "openvox-webui"
-version = "0.30.0"
+version = "0.30.2"
 dependencies = [
  "anyhow",
  "argon2",

--- a/src/db/inventory_repository.rs
+++ b/src/db/inventory_repository.rs
@@ -2885,6 +2885,9 @@ mod tests {
                 deployed_units: vec!["ROOT.war".to_string()],
                 metadata: None,
             }],
+            containers: vec![],
+            users: vec![],
+            repositories: vec![],
         };
 
         let inventory = repo

--- a/src/models/inventory.rs
+++ b/src/models/inventory.rs
@@ -76,6 +76,7 @@ pub struct HostApplicationInventoryItem {
 pub struct HostWebInventoryItem {
     pub server_type: String,
     pub site_name: String,
+    #[serde(default)]
     pub bindings: Vec<String>,
     pub document_root: Option<String>,
     pub application_pool: Option<String>,
@@ -90,6 +91,7 @@ pub struct HostRuntimeInventoryItem {
     pub runtime_version: Option<String>,
     pub install_path: Option<String>,
     pub management_endpoint: Option<String>,
+    #[serde(default)]
     pub deployed_units: Vec<String>,
     pub metadata: Option<serde_json::Value>,
 }
@@ -103,7 +105,9 @@ pub struct HostContainerInventoryItem {
     pub status: String,
     pub status_detail: Option<String>,
     pub created_at: Option<String>,
+    #[serde(default)]
     pub ports: Vec<String>,
+    #[serde(default)]
     pub mounts: Vec<String>,
     pub runtime_type: String,
     pub metadata: Option<serde_json::Value>,
@@ -118,6 +122,7 @@ pub struct HostUserInventoryItem {
     pub home_directory: Option<String>,
     pub shell: Option<String>,
     pub user_type: Option<String>,
+    #[serde(default)]
     pub groups: Vec<String>,
     pub last_login: Option<String>,
     pub locked: Option<bool>,


### PR DESCRIPTION
## Summary
- Nodes with synthetic container entries (e.g. `docker-engine` runtime) from older cached collectors omit `ports` and `mounts` arrays, causing Axum JSON deserialization to return 422 on `POST /inventory`
- This blocks the inventory→update-jobs polling flow, keeping update targets stuck in "queued" status indefinitely (affecting apldc1vds0044, apldc1vds0045, and 7 other nodes)
- Added `#[serde(default)]` to all `Vec<String>` fields in inventory model structs so missing arrays default to empty instead of failing deserialization

## Test plan
- [x] `cargo check` passes
- [x] `cargo test --lib` — 252 tests pass
- [ ] Deploy to segdc1vpr0018 and verify apldc1vds0044 inventory returns 201 on next puppet run
- [ ] Verify update jobs transition from "queued" to "dispatched"

🤖 Generated with [Claude Code](https://claude.com/claude-code)