### PR TITLE
Add missing react-is peer dependency for recharts

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openvox-webui-frontend",
-  "version": "0.30.2",
+  "version": "0.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openvox-webui-frontend",
-      "version": "0.30.2",
+      "version": "0.31.0",
       "dependencies": {
         "@tanstack/react-query": "^5.95.2",
         "axios": "^1.14.0",
@@ -15,6 +15,7 @@
         "lucide-react": "^1.7.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-is": "^19.2.4",
         "react-router-dom": "^7.13.2",
         "recharts": "^3.8.1",
         "zustand": "^5.0.11"
@@ -4275,6 +4276,12 @@
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/react-is": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
+      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "lucide-react": "^1.7.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-is": "^19.2.4",
     "react-router-dom": "^7.13.2",
     "recharts": "^3.8.1",
     "zustand": "^5.0.11"

--- a/puppet/CHANGELOG.md
+++ b/puppet/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `winget` as default Windows package repository source
 
 ### Fixed
+- Fix RPM/DEB package build failure caused by missing `react-is` peer dependency required by `recharts` v3
 - Fix inventory submission 422 error caused by container runtime entries missing the `image` field — make `image` optional in `HostContainerInventoryItem` so runtime-only entries (e.g. Docker Engine) are accepted
 - Install base64 gem for r10k compatibility with Ruby 3.2 (puppet_forge requires >= 0.2.0, but Ruby 3.2 only ships 0.1.1)
 - Fix dashboard stats grid layout: 5 status cards now fit on a single row instead of wrapping


### PR DESCRIPTION
## Changes

- Added `react-is@^19.2.4` as a dependency in `frontend/package.json`
- Updated `frontend/package-lock.json` with the new dependency
- Updated `puppet/CHANGELOG.md` to document the fix
- Bumped frontend version from 0.30.2 to 0.31.0

## Problem

The RPM/DEB package build was failing due to a missing `react-is` peer dependency required by `recharts` v3. This dependency is now explicitly declared to ensure it's included in package builds.