### PR TITLE
Add group update schedules and fix inventory issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3255,7 +3255,7 @@ dependencies = [
 
 [[package]]
 name = "openvox-webui"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "argon2",

--- a/frontend/src/components/analytics/UpdatesTab.tsx
+++ b/frontend/src/components/analytics/UpdatesTab.tsx
@@ -4,6 +4,7 @@ import {
   PieChart,
   Pie,
   Cell,
+  Legend,
   BarChart,
   Bar,
   XAxis,
@@ -183,24 +184,32 @@ export default function UpdatesTab() {
                     />
                   ))}
                 </Pie>
-                <Tooltip formatter={(value) => [String(value), 'Nodes']} />
+                <Tooltip formatter={(value: number, name: string) => [String(value), name]} />
+                <Legend
+                  formatter={(value: string) => {
+                    const entry = complianceData.find((d) => d.label === value);
+                    return `${value}: ${entry?.value ?? 0}`;
+                  }}
+                />
               </PieChart>
             </ResponsiveContainer>
           )}
           <div className="flex justify-center gap-6 mt-2">
-            {complianceData.map((entry) => (
-              <button
-                key={entry.label}
-                className="flex items-center gap-2 text-sm hover:underline"
-                onClick={() => setSelectedCompliance(entry.label.toLowerCase())}
-              >
-                <div
-                  className="w-3 h-3 rounded-full"
-                  style={{ backgroundColor: COMPLIANCE_COLORS[entry.label] ?? '#d1d5db' }}
-                />
-                {entry.label}: {entry.value}
-              </button>
-            ))}
+            {['Compliant', 'Outdated', 'Stale']
+              .filter((cat) => !complianceData.some((d) => d.label === cat))
+              .map((cat) => (
+                <button
+                  key={cat}
+                  className="flex items-center gap-2 text-sm text-gray-400"
+                  onClick={() => setSelectedCompliance(cat.toLowerCase())}
+                >
+                  <div
+                    className="w-3 h-3 rounded-full"
+                    style={{ backgroundColor: COMPLIANCE_COLORS[cat] ?? '#d1d5db' }}
+                  />
+                  {cat}: 0
+                </button>
+              ))}
           </div>
         </div>
 

--- a/frontend/src/pages/Groups.tsx
+++ b/frontend/src/pages/Groups.tsx
@@ -16,6 +16,9 @@ import {
   Edit2,
   AlertCircle,
   Variable,
+  CalendarClock,
+  Clock,
+  Play,
 } from 'lucide-react';
 import clsx from 'clsx';
 import { api } from '../services/api';
@@ -25,6 +28,9 @@ import type {
   RuleOperator,
   RuleMatchType,
   CreateRuleRequest,
+  GroupUpdateSchedule,
+  CreateGroupUpdateScheduleRequest,
+  UpdateOperationType,
 } from '../types';
 
 const RULE_OPERATORS: { value: RuleOperator; label: string; description: string }[] = [
@@ -44,7 +50,7 @@ export default function Groups() {
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [isEditOpen, setIsEditOpen] = useState(false);
   const [selectedGroup, setSelectedGroup] = useState<NodeGroup | null>(null);
-  const [activeTab, setActiveTab] = useState<'rules' | 'pinned' | 'classes' | 'variables'>('rules');
+  const [activeTab, setActiveTab] = useState<'rules' | 'pinned' | 'classes' | 'variables' | 'schedules'>('rules');
 
   // Create/Edit form state
   const [formName, setFormName] = useState('');
@@ -85,6 +91,17 @@ export default function Groups() {
   const [editingVariableKey, setEditingVariableKey] = useState<string | null>(null);
   const [editingVarKey, setEditingVarKey] = useState('');
   const [editingVarValue, setEditingVarValue] = useState('');
+
+  // Schedule form state
+  const [isAddScheduleOpen, setIsAddScheduleOpen] = useState(false);
+  const [newScheduleName, setNewScheduleName] = useState('');
+  const [newScheduleDescription, setNewScheduleDescription] = useState('');
+  const [newScheduleType, setNewScheduleType] = useState<'one_time' | 'recurring'>('recurring');
+  const [newScheduleCron, setNewScheduleCron] = useState('');
+  const [newScheduleDate, setNewScheduleDate] = useState('');
+  const [newScheduleOperationType, setNewScheduleOperationType] = useState<UpdateOperationType>('system_patch');
+  const [newSchedulePackageNames, setNewSchedulePackageNames] = useState('');
+  const [newScheduleRequiresApproval, setNewScheduleRequiresApproval] = useState(false);
 
   // Collapsed state for group tree (store IDs of collapsed groups)
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
@@ -225,6 +242,47 @@ export default function Groups() {
     },
   });
 
+  // Schedule queries and mutations
+  const { data: schedules = [] } = useQuery({
+    queryKey: ['group-schedules', selectedGroup?.id],
+    queryFn: () => api.getGroupUpdateSchedules(selectedGroup!.id),
+    enabled: !!selectedGroup,
+  });
+
+  const createScheduleMutation = useMutation({
+    mutationFn: ({ groupId, data }: { groupId: string; data: CreateGroupUpdateScheduleRequest }) =>
+      api.createGroupUpdateSchedule(groupId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['group-schedules'] });
+      setIsAddScheduleOpen(false);
+      resetScheduleForm();
+    },
+  });
+
+  const updateScheduleMutation = useMutation({
+    mutationFn: ({ groupId, scheduleId, data }: { groupId: string; scheduleId: string; data: { enabled?: boolean } }) =>
+      api.updateGroupUpdateSchedule(groupId, scheduleId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['group-schedules'] });
+    },
+  });
+
+  const deleteScheduleMutation = useMutation({
+    mutationFn: ({ groupId, scheduleId }: { groupId: string; scheduleId: string }) =>
+      api.deleteGroupUpdateSchedule(groupId, scheduleId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['group-schedules'] });
+    },
+  });
+
+  const runScheduleMutation = useMutation({
+    mutationFn: ({ groupId, scheduleId }: { groupId: string; scheduleId: string }) =>
+      api.runGroupUpdateSchedule(groupId, scheduleId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['group-schedules'] });
+    },
+  });
+
   const resetForm = () => {
     setFormName('');
     setFormDescription('');
@@ -257,6 +315,46 @@ export default function Groups() {
     setEditingVariableKey(null);
     setEditingVarKey('');
     setEditingVarValue('');
+  };
+
+  const resetScheduleForm = () => {
+    setNewScheduleName('');
+    setNewScheduleDescription('');
+    setNewScheduleType('recurring');
+    setNewScheduleCron('');
+    setNewScheduleDate('');
+    setNewScheduleOperationType('system_patch');
+    setNewSchedulePackageNames('');
+    setNewScheduleRequiresApproval(false);
+  };
+
+  const handleAddSchedule = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedGroup || !newScheduleName.trim()) return;
+
+    const data: CreateGroupUpdateScheduleRequest = {
+      name: newScheduleName.trim(),
+      description: newScheduleDescription.trim() || undefined,
+      schedule_type: newScheduleType,
+      operation_type: newScheduleOperationType,
+      requires_approval: newScheduleRequiresApproval,
+    };
+    if (newScheduleType === 'recurring' && newScheduleCron.trim()) {
+      data.cron_expression = newScheduleCron.trim();
+    }
+    if (newScheduleType === 'one_time' && newScheduleDate) {
+      data.scheduled_for = new Date(newScheduleDate).toISOString();
+    }
+    if (newScheduleOperationType === 'package_update' && newSchedulePackageNames.trim()) {
+      data.package_names = newSchedulePackageNames.split(',').map(s => s.trim()).filter(Boolean);
+    }
+
+    createScheduleMutation.mutate({ groupId: selectedGroup.id, data });
+  };
+
+  const formatScheduleDate = (dateStr: string | null | undefined): string => {
+    if (!dateStr) return 'N/A';
+    return new Date(dateStr).toLocaleString();
   };
 
   const serializeValueForInput = (value: unknown): string => {
@@ -856,6 +954,7 @@ export default function Groups() {
                     { id: 'pinned', label: 'Pinned Nodes', icon: Pin },
                     { id: 'classes', label: 'Classes', icon: Settings },
                     { id: 'variables', label: 'Variables', icon: Variable },
+                    { id: 'schedules', label: 'Update Schedules', icon: CalendarClock },
                   ].map(tab => (
                     <button
                       key={tab.id}
@@ -887,6 +986,11 @@ export default function Groups() {
                       {tab.id === 'variables' && (
                         <span className="ml-2 bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full text-xs">
                           {Object.keys(selectedGroup.variables || {}).length}
+                        </span>
+                      )}
+                      {tab.id === 'schedules' && (
+                        <span className="ml-2 bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full text-xs">
+                          {schedules.length}
                         </span>
                       )}
                     </button>
@@ -1360,6 +1464,283 @@ export default function Groups() {
                         <p className="text-xs text-gray-400 mt-1">
                           Add classes to apply Puppet modules to nodes in this group
                         </p>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {/* Schedules Tab */}
+              {activeTab === 'schedules' && (
+                <div>
+                  <div className="flex items-center justify-between mb-4">
+                    <p className="text-sm text-gray-600">
+                      Define automatic or approval-required update schedules for this group's nodes.
+                    </p>
+                    <button
+                      onClick={() => setIsAddScheduleOpen(true)}
+                      className="btn btn-secondary text-sm flex items-center"
+                    >
+                      <Plus className="w-4 h-4 mr-1" />
+                      Add Schedule
+                    </button>
+                  </div>
+
+                  {/* Add Schedule Form */}
+                  {isAddScheduleOpen && (
+                    <div className="bg-gray-50 rounded-lg p-4 mb-4 border border-gray-200">
+                      <form onSubmit={handleAddSchedule} className="space-y-4">
+                        <div>
+                          <label className="label">Name</label>
+                          <input
+                            type="text"
+                            value={newScheduleName}
+                            onChange={(e) => setNewScheduleName(e.target.value)}
+                            className="input"
+                            placeholder="e.g., Weekly security patches"
+                            required
+                          />
+                        </div>
+                        <div>
+                          <label className="label">Description</label>
+                          <input
+                            type="text"
+                            value={newScheduleDescription}
+                            onChange={(e) => setNewScheduleDescription(e.target.value)}
+                            className="input"
+                            placeholder="Optional description..."
+                          />
+                        </div>
+                        <div>
+                          <label className="label">Schedule Type</label>
+                          <div className="flex gap-2">
+                            <button
+                              type="button"
+                              onClick={() => setNewScheduleType('one_time')}
+                              className={clsx(
+                                'btn text-sm',
+                                newScheduleType === 'one_time' ? 'btn-primary' : 'btn-secondary'
+                              )}
+                            >
+                              One-time
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => setNewScheduleType('recurring')}
+                              className={clsx(
+                                'btn text-sm',
+                                newScheduleType === 'recurring' ? 'btn-primary' : 'btn-secondary'
+                              )}
+                            >
+                              Recurring
+                            </button>
+                          </div>
+                        </div>
+                        {newScheduleType === 'one_time' ? (
+                          <div>
+                            <label className="label">Date & Time</label>
+                            <input
+                              type="datetime-local"
+                              value={newScheduleDate}
+                              onChange={(e) => setNewScheduleDate(e.target.value)}
+                              className="input"
+                              required
+                            />
+                          </div>
+                        ) : (
+                          <div>
+                            <label className="label">Cron Expression</label>
+                            <input
+                              type="text"
+                              value={newScheduleCron}
+                              onChange={(e) => setNewScheduleCron(e.target.value)}
+                              className="input"
+                              placeholder="e.g., 0 0 2 * * *"
+                              required
+                            />
+                            <p className="text-xs text-gray-500 mt-1">6-field cron: sec min hour dom month dow</p>
+                            <div className="flex gap-2 mt-2">
+                              <button
+                                type="button"
+                                onClick={() => setNewScheduleCron('0 0 2 * * *')}
+                                className="text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 px-2 py-1 rounded"
+                              >
+                                Daily 2AM
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => setNewScheduleCron('0 0 3 * * SUN')}
+                                className="text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 px-2 py-1 rounded"
+                              >
+                                Weekly Sun 3AM
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => setNewScheduleCron('0 0 4 1 * *')}
+                                className="text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 px-2 py-1 rounded"
+                              >
+                                Monthly 1st 4AM
+                              </button>
+                            </div>
+                          </div>
+                        )}
+                        <div>
+                          <label className="label">Operation Type</label>
+                          <select
+                            value={newScheduleOperationType}
+                            onChange={(e) => setNewScheduleOperationType(e.target.value as UpdateOperationType)}
+                            className="input"
+                          >
+                            <option value="system_patch">System Patch</option>
+                            <option value="security_patch">Security Patch</option>
+                            <option value="package_update">Package Update</option>
+                          </select>
+                        </div>
+                        {newScheduleOperationType === 'package_update' && (
+                          <div>
+                            <label className="label">Package Names (comma-separated)</label>
+                            <input
+                              type="text"
+                              value={newSchedulePackageNames}
+                              onChange={(e) => setNewSchedulePackageNames(e.target.value)}
+                              className="input"
+                              placeholder="e.g., nginx, openssl, curl"
+                            />
+                          </div>
+                        )}
+                        <div className="flex items-center">
+                          <label className="flex items-center cursor-pointer">
+                            <input
+                              type="checkbox"
+                              checked={newScheduleRequiresApproval}
+                              onChange={(e) => setNewScheduleRequiresApproval(e.target.checked)}
+                              className="mr-2"
+                            />
+                            <span className="text-sm font-medium text-gray-700">Requires Approval</span>
+                          </label>
+                        </div>
+                        <div className="flex justify-end gap-2">
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setIsAddScheduleOpen(false);
+                              resetScheduleForm();
+                            }}
+                            className="btn btn-secondary text-sm"
+                          >
+                            Cancel
+                          </button>
+                          <button
+                            type="submit"
+                            disabled={createScheduleMutation.isPending}
+                            className="btn btn-primary text-sm"
+                          >
+                            {createScheduleMutation.isPending ? 'Saving...' : 'Save'}
+                          </button>
+                        </div>
+                      </form>
+                    </div>
+                  )}
+
+                  {/* Schedule List */}
+                  <div className="space-y-3">
+                    {schedules.length > 0 ? (
+                      schedules.map((schedule: GroupUpdateSchedule) => (
+                        <div
+                          key={schedule.id}
+                          className="bg-white border border-gray-200 rounded-lg px-4 py-3"
+                        >
+                          <div className="flex items-start justify-between">
+                            <div className="min-w-0 flex-1">
+                              <div className="flex items-center gap-2 mb-1">
+                                <span className="font-medium text-gray-900">{schedule.name}</span>
+                                <span className="text-xs bg-primary-100 text-primary-700 px-2 py-0.5 rounded-full">
+                                  {schedule.operation_type === 'system_patch' ? 'System Patch' :
+                                   schedule.operation_type === 'security_patch' ? 'Security Patch' : 'Package Update'}
+                                </span>
+                              </div>
+                              {schedule.description && (
+                                <p className="text-sm text-gray-500 mb-2">{schedule.description}</p>
+                              )}
+                              <div className="flex items-center gap-4 text-sm text-gray-500">
+                                <span className="flex items-center gap-1">
+                                  <Clock className="w-3.5 h-3.5" />
+                                  {schedule.schedule_type === 'recurring'
+                                    ? `Recurring: ${schedule.cron_expression}`
+                                    : `One-time: ${formatScheduleDate(schedule.scheduled_for)}`}
+                                </span>
+                                {schedule.requires_approval ? (
+                                  <span className="text-xs bg-yellow-100 text-yellow-700 px-2 py-0.5 rounded-full">
+                                    Requires Approval
+                                  </span>
+                                ) : (
+                                  <span className="text-xs bg-green-100 text-green-700 px-2 py-0.5 rounded-full">
+                                    Auto
+                                  </span>
+                                )}
+                              </div>
+                              <div className="flex items-center gap-4 mt-1 text-xs text-gray-400">
+                                <span>Next run: {formatScheduleDate(schedule.next_run_at)}</span>
+                                <span>Last run: {formatScheduleDate(schedule.last_run_at)}</span>
+                              </div>
+                            </div>
+                            <div className="flex items-center gap-2 ml-4 flex-shrink-0">
+                              <button
+                                onClick={() =>
+                                  updateScheduleMutation.mutate({
+                                    groupId: selectedGroup!.id,
+                                    scheduleId: schedule.id,
+                                    data: { enabled: !schedule.enabled },
+                                  })
+                                }
+                                className={clsx(
+                                  'relative inline-flex h-6 w-11 items-center rounded-full transition-colors',
+                                  schedule.enabled ? 'bg-primary-600' : 'bg-gray-300'
+                                )}
+                                title={schedule.enabled ? 'Disable' : 'Enable'}
+                              >
+                                <span
+                                  className={clsx(
+                                    'inline-block h-4 w-4 transform rounded-full bg-white transition-transform',
+                                    schedule.enabled ? 'translate-x-6' : 'translate-x-1'
+                                  )}
+                                />
+                              </button>
+                              <button
+                                onClick={() =>
+                                  runScheduleMutation.mutate({
+                                    groupId: selectedGroup!.id,
+                                    scheduleId: schedule.id,
+                                  })
+                                }
+                                disabled={runScheduleMutation.isPending}
+                                className="text-gray-400 hover:text-primary-600 transition-colors"
+                                title="Run Now"
+                              >
+                                <Play className="w-4 h-4" />
+                              </button>
+                              <button
+                                onClick={() =>
+                                  deleteScheduleMutation.mutate({
+                                    groupId: selectedGroup!.id,
+                                    scheduleId: schedule.id,
+                                  })
+                                }
+                                disabled={deleteScheduleMutation.isPending}
+                                className="text-gray-400 hover:text-red-600 transition-colors"
+                                title="Delete schedule"
+                              >
+                                <X className="w-4 h-4" />
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      ))
+                    ) : (
+                      <div className="text-center py-8 text-gray-500 bg-gray-50 rounded-lg">
+                        <CalendarClock className="w-8 h-8 mx-auto mb-2 text-gray-300" />
+                        <p>No update schedules defined</p>
+                        <p className="text-sm mt-1">Create one to automate updates for this group's nodes.</p>
                       </div>
                     )}
                   </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -128,6 +128,9 @@ import type {
   UpdateJob,
   CreateUpdateJobRequest,
   ApproveUpdateJobRequest,
+  GroupUpdateSchedule,
+  CreateGroupUpdateScheduleRequest,
+  UpdateGroupUpdateScheduleRequest,
   OutdatedSoftwareNodeDetail,
   ComplianceCategoryNode,
   FleetRepositoryConfig,
@@ -380,6 +383,31 @@ export const api = {
 
   removePinnedNode: async (groupId: string, certname: string): Promise<void> => {
     await client.delete(`/groups/${groupId}/pinned/${encodeURIComponent(certname)}`);
+  },
+
+  // Group Update Schedules
+  getGroupUpdateSchedules: async (groupId: string): Promise<GroupUpdateSchedule[]> => {
+    const response = await client.get(`/groups/${groupId}/update-schedules`);
+    return response.data;
+  },
+
+  createGroupUpdateSchedule: async (groupId: string, data: CreateGroupUpdateScheduleRequest): Promise<GroupUpdateSchedule> => {
+    const response = await client.post(`/groups/${groupId}/update-schedules`, data);
+    return response.data;
+  },
+
+  updateGroupUpdateSchedule: async (groupId: string, scheduleId: string, data: UpdateGroupUpdateScheduleRequest): Promise<GroupUpdateSchedule> => {
+    const response = await client.put(`/groups/${groupId}/update-schedules/${scheduleId}`, data);
+    return response.data;
+  },
+
+  deleteGroupUpdateSchedule: async (groupId: string, scheduleId: string): Promise<void> => {
+    await client.delete(`/groups/${groupId}/update-schedules/${scheduleId}`);
+  },
+
+  runGroupUpdateSchedule: async (groupId: string, scheduleId: string): Promise<UpdateJob> => {
+    const response = await client.post(`/groups/${groupId}/update-schedules/${scheduleId}/run`);
+    return response.data;
   },
 
   // Facts

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -203,6 +203,7 @@ export interface RepositoryVersionCatalogEntry {
   id: string;
   platform_family: string;
   distribution: string;
+  os_version_pattern?: string | null;
   package_manager?: string | null;
   software_type: string;
   software_name: string;
@@ -214,6 +215,56 @@ export interface RepositoryVersionCatalogEntry {
   last_seen_at: string;
   created_at: string;
   updated_at: string;
+}
+
+// Group Update Schedules
+
+export interface GroupUpdateSchedule {
+  id: string;
+  group_id: string;
+  name: string;
+  description?: string | null;
+  schedule_type: 'one_time' | 'recurring';
+  cron_expression?: string | null;
+  scheduled_for?: string | null;
+  operation_type: UpdateOperationType;
+  package_names: string[];
+  requires_approval: boolean;
+  maintenance_window_start?: string | null;
+  maintenance_window_end?: string | null;
+  enabled: boolean;
+  last_run_at?: string | null;
+  next_run_at?: string | null;
+  last_job_id?: string | null;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateGroupUpdateScheduleRequest {
+  name: string;
+  description?: string;
+  schedule_type: 'one_time' | 'recurring';
+  cron_expression?: string;
+  scheduled_for?: string;
+  operation_type: UpdateOperationType;
+  package_names?: string[];
+  requires_approval?: boolean;
+  maintenance_window_start?: string;
+  maintenance_window_end?: string;
+}
+
+export interface UpdateGroupUpdateScheduleRequest {
+  name?: string;
+  description?: string;
+  cron_expression?: string;
+  scheduled_for?: string;
+  operation_type?: UpdateOperationType;
+  package_names?: string[];
+  requires_approval?: boolean;
+  maintenance_window_start?: string;
+  maintenance_window_end?: string;
+  enabled?: boolean;
 }
 
 export interface InventoryFleetStatusSummary {

--- a/migrations/20260407000001_catalog_os_version.sql
+++ b/migrations/20260407000001_catalog_os_version.sql
@@ -1,0 +1,19 @@
+-- Add os_version_pattern to repository_version_catalog to separate
+-- packages by OS major version (e.g., el8 vs el9)
+
+ALTER TABLE repository_version_catalog ADD COLUMN os_version_pattern TEXT;
+
+-- Recreate the unique index to include os_version_pattern and source_kind
+DROP INDEX IF EXISTS idx_repository_version_catalog_identity;
+
+CREATE UNIQUE INDEX idx_repository_version_catalog_identity
+    ON repository_version_catalog(
+        platform_family,
+        distribution,
+        package_manager,
+        software_type,
+        software_name,
+        COALESCE(repository_source, ''),
+        source_kind,
+        COALESCE(os_version_pattern, '')
+    );

--- a/migrations/20260407000002_group_update_schedules.sql
+++ b/migrations/20260407000002_group_update_schedules.sql
@@ -1,0 +1,30 @@
+-- Group Update Schedules: recurring and one-time update policies for node groups
+
+CREATE TABLE IF NOT EXISTS group_update_schedules (
+    id TEXT PRIMARY KEY,
+    group_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    schedule_type TEXT NOT NULL,                    -- 'one_time' | 'recurring'
+    cron_expression TEXT,                           -- 6-field cron for recurring (sec min hour dom month dow)
+    scheduled_for TEXT,                             -- ISO8601 timestamp for one-time
+    operation_type TEXT NOT NULL,                   -- system_patch | security_patch | package_update
+    package_names_json TEXT NOT NULL DEFAULT '[]',
+    requires_approval INTEGER NOT NULL DEFAULT 0,
+    maintenance_window_start TEXT,
+    maintenance_window_end TEXT,
+    enabled INTEGER NOT NULL DEFAULT 1,
+    last_run_at TEXT,
+    next_run_at TEXT,
+    last_job_id TEXT,
+    created_by TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY(group_id) REFERENCES node_groups(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_group_update_schedules_group
+    ON group_update_schedules(group_id);
+
+CREATE INDEX IF NOT EXISTS idx_group_update_schedules_due
+    ON group_update_schedules(enabled, next_run_at);

--- a/puppet/CHANGELOG.md
+++ b/puppet/CHANGELOG.md
@@ -24,8 +24,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add facter collector methods for YUM, APT, Zypper, and Winget repository discovery
 - Add `source_kind` field to `OutdatedInventoryItem` to distinguish "repo-checked" vs "fleet-observed" outdated determinations
 - Add `winget` as default Windows package repository source
+- Add "Update Schedules" tab to Node Groups for scheduling one-time and recurring (cron-based) update tasks with optional approval workflows
+- Add `group_update_schedules` database table and full CRUD API (`GET/POST /groups/:id/update-schedules`, `PUT/DELETE /groups/:id/update-schedules/:scheduleId`, `POST .../run`)
+- Add background update schedule scheduler that auto-creates UpdateJobs when schedules are due
 
 ### Fixed
+- Detect last successful system update time from dnf/yum history, apt logs, and zypper history instead of always reporting "Never recorded"
+- Fix false-positive outdated package detection when fleet has nodes on different OS major versions (e.g., el8 vs el9) by adding `os_version_pattern` dimension to the version catalog
+- Fix Update Compliance donut chart legend showing "value" instead of proper category labels (Compliant/Outdated/Stale); always include all 3 compliance categories even when count is zero
 - Fix RPM/DEB package build failure caused by missing `react-is` peer dependency required by `recharts` v3
 - Fix inventory submission 422 error caused by container runtime entries missing the `image` field — make `image` optional in `HostContainerInventoryItem` so runtime-only entries (e.g. Docker Engine) are accepted
 - Install base64 gem for r10k compatibility with Ruby 3.2 (puppet_forge requires >= 0.2.0, but Ruby 3.2 only ships 0.1.1)

--- a/puppet/lib/facter/openvox_inventory.rb
+++ b/puppet/lib/facter/openvox_inventory.rb
@@ -158,7 +158,7 @@ module OpenVoxInventory
       'package_manager' => detect_package_manager(os_fact),
       'update_channel' => nil,
       'last_inventory_at' => collected_at,
-      'last_successful_update_at' => nil
+      'last_successful_update_at' => detect_last_successful_update(os_fact)
     }
   end
 
@@ -177,6 +177,107 @@ module OpenVoxInventory
     else
       nil
     end
+  end
+
+  def detect_last_successful_update(os_fact)
+    family = os_fact['family']
+    timestamp = case family
+                when 'RedHat'
+                  detect_last_update_rpm
+                when 'Debian'
+                  detect_last_update_apt
+                when 'Suse'
+                  detect_last_update_zypper
+                else
+                  nil
+                end
+    timestamp&.utc&.iso8601
+  rescue StandardError => e
+    Facter.debug("openvox_inventory: Failed to detect last update time: #{e.message}")
+    nil
+  end
+
+  def detect_last_update_rpm
+    # Try dnf first, fall back to yum
+    output = run_command('dnf history list 2>/dev/null') ||
+             run_command('yum history list all 2>/dev/null')
+    return nil if output.nil? || output.empty?
+
+    # dnf history output format (varies by version):
+    #   ID | Command line | Date and time    | Action(s) | Altered
+    #   15 | update -y    | 2025-03-15 10:23 | Update    |   42
+    # Look for the last line with an Update/Upgrade action
+    last_date = nil
+    output.each_line do |line|
+      next unless line =~ /\b(Update|Upgrade|U|I,\s*U)\b/i
+      if line =~ /(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2})/
+        begin
+          last_date = Time.parse(Regexp.last_match(1))
+        rescue StandardError
+          nil
+        end
+      end
+    end
+    last_date
+  rescue StandardError
+    nil
+  end
+
+  def detect_last_update_apt
+    # Check /var/log/apt/history.log for the latest End-Date of an upgrade
+    last_date = nil
+
+    if File.exist?('/var/log/apt/history.log')
+      File.readlines('/var/log/apt/history.log').each do |line|
+        if line =~ /^End-Date:\s+(.+)/
+          begin
+            last_date = Time.parse(Regexp.last_match(1).strip)
+          rescue StandardError
+            nil
+          end
+        end
+      end
+    end
+
+    # Fallback: check dpkg.log for last configure/install action
+    if last_date.nil? && File.exist?('/var/log/dpkg.log')
+      File.readlines('/var/log/dpkg.log').reverse_each do |line|
+        if line =~ /^(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2})\s+(configure|install)/
+          begin
+            last_date = Time.parse(Regexp.last_match(1))
+            break
+          rescue StandardError
+            nil
+          end
+        end
+      end
+    end
+
+    last_date
+  rescue StandardError
+    nil
+  end
+
+  def detect_last_update_zypper
+    # /var/log/zypp/history format: "timestamp|action|..."
+    return nil unless File.exist?('/var/log/zypp/history')
+
+    last_date = nil
+    File.readlines('/var/log/zypp/history').each do |line|
+      next if line.start_with?('#')
+      parts = line.split('|')
+      next if parts.length < 2
+      action = parts[1].to_s.strip.downcase
+      next unless action =~ /install|update/
+      begin
+        last_date = Time.parse(parts[0].strip)
+      rescue StandardError
+        nil
+      end
+    end
+    last_date
+  rescue StandardError
+    nil
   end
 
   def collect_linux_rpm_packages(_config)

--- a/src/api/groups.rs
+++ b/src/api/groups.rs
@@ -10,11 +10,12 @@ use serde::Deserialize;
 use uuid::Uuid;
 
 use crate::{
-    db::repository::GroupRepository,
+    db::{repository::GroupRepository, InventoryRepository},
     middleware::AuthUser,
     models::{
-        Action, AddPinnedNodeRequest, ClassificationRule, CreateGroupRequest, CreateRuleRequest,
-        NodeGroup, Resource, UpdateGroupRequest,
+        Action, AddPinnedNodeRequest, ClassificationRule, CreateGroupRequest,
+        CreateGroupUpdateScheduleRequest, CreateRuleRequest, GroupUpdateSchedule, NodeGroup,
+        Resource, UpdateGroupRequest, UpdateGroupUpdateScheduleRequest, UpdateJob,
     },
     utils::AppError,
     AppState,
@@ -33,6 +34,20 @@ pub fn routes() -> Router<AppState> {
         .route("/{id}/rules/{rule_id}", delete(delete_rule))
         .route("/{id}/pinned", post(add_pinned_node))
         .route("/{id}/pinned/{certname}", delete(remove_pinned_node))
+        .route(
+            "/{id}/update-schedules",
+            get(list_update_schedules).post(create_update_schedule),
+        )
+        .route(
+            "/{id}/update-schedules/{schedule_id}",
+            get(get_update_schedule)
+                .put(update_update_schedule)
+                .delete(delete_update_schedule),
+        )
+        .route(
+            "/{id}/update-schedules/{schedule_id}/run",
+            post(run_update_schedule),
+        )
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -472,4 +487,172 @@ async fn remove_pinned_node(
     } else {
         Err(AppError::not_found("Pinned node not found"))
     }
+}
+
+// ── Update Schedule Endpoints ──────────────────────────────────────
+
+async fn list_update_schedules(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(id): Path<String>,
+) -> Result<Json<Vec<GroupUpdateSchedule>>, AppError> {
+    check_group_permission(&state, &auth_user, Action::Read, None).await?;
+
+    let repo = InventoryRepository::new(state.db.clone());
+    let schedules = repo
+        .list_group_update_schedules(&id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to list update schedules: {}", e);
+            AppError::internal("Failed to list update schedules")
+        })?;
+
+    Ok(Json(schedules))
+}
+
+async fn create_update_schedule(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(id): Path<String>,
+    Json(payload): Json<CreateGroupUpdateScheduleRequest>,
+) -> Result<(StatusCode, Json<GroupUpdateSchedule>), AppError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| AppError::bad_request("Invalid group ID"))?;
+    check_group_permission(&state, &auth_user, Action::Update, Some(uuid)).await?;
+
+    let repo = InventoryRepository::new(state.db.clone());
+    let schedule = repo
+        .create_group_update_schedule(&id, &payload, &auth_user.username)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to create update schedule: {}", e);
+            AppError::bad_request(&format!("Failed to create update schedule: {}", e))
+        })?;
+
+    Ok((StatusCode::CREATED, Json(schedule)))
+}
+
+async fn get_update_schedule(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path((id, schedule_id)): Path<(String, String)>,
+) -> Result<Json<GroupUpdateSchedule>, AppError> {
+    let _uuid = Uuid::parse_str(&id).map_err(|_| AppError::bad_request("Invalid group ID"))?;
+    check_group_permission(&state, &auth_user, Action::Read, None).await?;
+
+    let repo = InventoryRepository::new(state.db.clone());
+    let schedule = repo
+        .get_group_update_schedule(&schedule_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to fetch update schedule: {}", e);
+            AppError::internal("Failed to fetch update schedule")
+        })?
+        .ok_or_else(|| AppError::not_found("Update schedule not found"))?;
+
+    Ok(Json(schedule))
+}
+
+async fn update_update_schedule(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path((id, schedule_id)): Path<(String, String)>,
+    Json(payload): Json<UpdateGroupUpdateScheduleRequest>,
+) -> Result<Json<GroupUpdateSchedule>, AppError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| AppError::bad_request("Invalid group ID"))?;
+    check_group_permission(&state, &auth_user, Action::Update, Some(uuid)).await?;
+
+    let repo = InventoryRepository::new(state.db.clone());
+    let schedule = repo
+        .update_group_update_schedule(&schedule_id, &payload)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to update schedule: {}", e);
+            AppError::bad_request(&format!("Failed to update schedule: {}", e))
+        })?
+        .ok_or_else(|| AppError::not_found("Update schedule not found"))?;
+
+    Ok(Json(schedule))
+}
+
+async fn delete_update_schedule(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path((id, schedule_id)): Path<(String, String)>,
+) -> Result<StatusCode, AppError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| AppError::bad_request("Invalid group ID"))?;
+    check_group_permission(&state, &auth_user, Action::Update, Some(uuid)).await?;
+
+    let repo = InventoryRepository::new(state.db.clone());
+    let deleted = repo
+        .delete_group_update_schedule(&schedule_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to delete update schedule: {}", e);
+            AppError::internal("Failed to delete update schedule")
+        })?;
+
+    if deleted {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(AppError::not_found("Update schedule not found"))
+    }
+}
+
+/// Manually trigger a schedule: resolve group members and create an UpdateJob
+async fn run_update_schedule(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path((id, schedule_id)): Path<(String, String)>,
+) -> Result<(StatusCode, Json<UpdateJob>), AppError> {
+    let uuid = Uuid::parse_str(&id).map_err(|_| AppError::bad_request("Invalid group ID"))?;
+    check_group_permission(&state, &auth_user, Action::Update, Some(uuid)).await?;
+
+    let inv_repo = InventoryRepository::new(state.db.clone());
+    let schedule = inv_repo
+        .get_group_update_schedule(&schedule_id)
+        .await
+        .map_err(|e| AppError::internal(&format!("Failed to fetch schedule: {}", e)))?
+        .ok_or_else(|| AppError::not_found("Update schedule not found"))?;
+
+    // Resolve group members
+    let group_repo = GroupRepository::new(&state.db);
+    let certnames = group_repo
+        .get_group_nodes(uuid)
+        .await
+        .map_err(|e| AppError::internal(&format!("Failed to resolve group nodes: {}", e)))?;
+
+    if certnames.is_empty() {
+        return Err(AppError::bad_request(
+            "No nodes found in this group to update",
+        ));
+    }
+
+    let job = inv_repo
+        .create_update_job(
+            schedule.operation_type,
+            &schedule.package_names,
+            Some(&id),
+            &certnames,
+            schedule.requires_approval,
+            None, // immediate execution
+            None,
+            None,
+            &auth_user.username,
+            Some(&format!("Manually triggered from schedule '{}'", schedule.name)),
+        )
+        .await
+        .map_err(|e| AppError::internal(&format!("Failed to create update job: {}", e)))?;
+
+    // Update schedule last_run_at
+    let _ = inv_repo
+        .update_schedule_after_run(
+            &schedule_id,
+            chrono::Utc::now(),
+            schedule.next_run_at, // keep existing next_run_at
+            &job.id,
+            false,
+        )
+        .await;
+
+    Ok((StatusCode::CREATED, Json(job)))
 }

--- a/src/db/inventory_repository.rs
+++ b/src/db/inventory_repository.rs
@@ -6,14 +6,15 @@ use sqlx::{FromRow, SqlitePool};
 use uuid::Uuid;
 
 use crate::models::{
-    ComplianceCategoryNode, FleetRepositoryConfig, HostApplicationInventoryItem,
-    HostContainerInventoryItem, HostOsInventory, HostPackageInventoryItem,
-    HostRepositoryConfig, HostRuntimeInventoryItem, HostUpdateStatus,
-    HostUserInventoryItem, HostWebInventoryItem, InventoryDashboardReport,
-    InventoryDistributionPoint, InventoryFleetStatusSummary, InventoryPayload,
-    InventorySnapshotSummary, InventorySummary, NodeInventory, NodePendingUpdateJob,
-    OutdatedInventoryItem, OutdatedSoftwareNodeDetail, PatchAgeBucket,
-    RepositoryVersionCatalogEntry, SubmitUpdateJobResultRequest, TopOutdatedSoftwareItem,
+    ComplianceCategoryNode, CreateGroupUpdateScheduleRequest, FleetRepositoryConfig,
+    GroupUpdateSchedule, HostApplicationInventoryItem, HostContainerInventoryItem,
+    HostOsInventory, HostPackageInventoryItem, HostRepositoryConfig,
+    HostRuntimeInventoryItem, HostUpdateStatus, HostUserInventoryItem,
+    HostWebInventoryItem, InventoryDashboardReport, InventoryDistributionPoint,
+    InventoryFleetStatusSummary, InventoryPayload, InventorySnapshotSummary,
+    InventorySummary, NodeInventory, NodePendingUpdateJob, OutdatedInventoryItem,
+    OutdatedSoftwareNodeDetail, PatchAgeBucket, RepositoryVersionCatalogEntry,
+    SubmitUpdateJobResultRequest, TopOutdatedSoftwareItem, UpdateGroupUpdateScheduleRequest,
     UpdateJob, UpdateJobResult, UpdateJobStatus, UpdateJobTarget, UpdateOperationType,
     UpdateTargetStatus,
 };
@@ -335,12 +336,20 @@ impl InventoryRepository {
         let now = Utc::now();
         let package_rows = sqlx::query_as::<_, CatalogPackageObservationRow>(
             r#"
-            SELECT o.os_family, o.distribution, o.package_manager, p.name, p.repository_source,
+            SELECT o.os_family, o.distribution,
+                   CASE WHEN INSTR(o.os_version, '.') > 0
+                        THEN SUBSTR(o.os_version, 1, INSTR(o.os_version, '.') - 1)
+                        ELSE o.os_version END AS os_version_pattern,
+                   o.package_manager, p.name, p.repository_source,
                    p.version, p.release, MAX(s.collected_at) AS last_seen_at, COUNT(DISTINCT p.certname) AS observed_nodes
             FROM host_package_inventory p
             INNER JOIN host_os_inventory o ON o.certname = p.certname
             INNER JOIN host_inventory_snapshots s ON s.id = p.snapshot_id
-            GROUP BY o.os_family, o.distribution, o.package_manager, p.name, p.repository_source, p.version, p.release
+            GROUP BY o.os_family, o.distribution,
+                     CASE WHEN INSTR(o.os_version, '.') > 0
+                          THEN SUBSTR(o.os_version, 1, INSTR(o.os_version, '.') - 1)
+                          ELSE o.os_version END,
+                     o.package_manager, p.name, p.repository_source, p.version, p.release
             "#
         )
         .fetch_all(&self.pool)
@@ -349,12 +358,20 @@ impl InventoryRepository {
 
         let application_rows = sqlx::query_as::<_, CatalogApplicationObservationRow>(
             r#"
-            SELECT o.os_family, o.distribution, o.package_manager, a.name, a.publisher, a.application_type,
+            SELECT o.os_family, o.distribution,
+                   CASE WHEN INSTR(o.os_version, '.') > 0
+                        THEN SUBSTR(o.os_version, 1, INSTR(o.os_version, '.') - 1)
+                        ELSE o.os_version END AS os_version_pattern,
+                   o.package_manager, a.name, a.publisher, a.application_type,
                    a.version, MAX(s.collected_at) AS last_seen_at, COUNT(DISTINCT a.certname) AS observed_nodes
             FROM host_application_inventory a
             INNER JOIN host_os_inventory o ON o.certname = a.certname
             INNER JOIN host_inventory_snapshots s ON s.id = a.snapshot_id
-            GROUP BY o.os_family, o.distribution, o.package_manager, a.name, a.publisher, a.application_type, a.version
+            GROUP BY o.os_family, o.distribution,
+                     CASE WHEN INSTR(o.os_version, '.') > 0
+                          THEN SUBSTR(o.os_version, 1, INSTR(o.os_version, '.') - 1)
+                          ELSE o.os_version END,
+                     o.package_manager, a.name, a.publisher, a.application_type, a.version
             "#
         )
         .fetch_all(&self.pool)
@@ -401,7 +418,7 @@ impl InventoryRepository {
         let catalogs = self.list_version_catalog().await?;
         let package_rows = sqlx::query_as::<_, HostPackageJoinedRow>(
             r#"
-            SELECT p.certname, o.os_family, o.distribution, o.package_manager, p.name, p.version, p.release, p.repository_source
+            SELECT p.certname, o.os_family, o.distribution, o.os_version, o.package_manager, p.name, p.version, p.release, p.repository_source
             FROM host_package_inventory p
             INNER JOIN host_os_inventory o ON o.certname = p.certname
             ORDER BY p.certname ASC
@@ -412,7 +429,7 @@ impl InventoryRepository {
         .context("Failed to load package inventory for update status")?;
         let application_rows = sqlx::query_as::<_, HostApplicationJoinedRow>(
             r#"
-            SELECT a.certname, o.os_family, o.distribution, o.package_manager, a.name, a.version, a.publisher, a.application_type
+            SELECT a.certname, o.os_family, o.distribution, o.os_version, o.package_manager, a.name, a.version, a.publisher, a.application_type
             FROM host_application_inventory a
             INNER JOIN host_os_inventory o ON o.certname = a.certname
             ORDER BY a.certname ASC
@@ -658,20 +675,21 @@ impl InventoryRepository {
             summary,
             platform_distribution: map_distribution(platform_distribution),
             os_distribution: map_distribution(os_distribution),
-            update_compliance: map_distribution(vec![
-                DashboardDistributionRow {
+            // Always include all compliance categories (even when 0) so the chart legend is complete
+            update_compliance: vec![
+                InventoryDistributionPoint {
                     label: "Compliant".to_string(),
-                    value: compliance_rows.compliant_nodes,
+                    value: compliance_rows.compliant_nodes.max(0) as usize,
                 },
-                DashboardDistributionRow {
+                InventoryDistributionPoint {
                     label: "Outdated".to_string(),
-                    value: compliance_rows.outdated_nodes,
+                    value: compliance_rows.outdated_nodes.max(0) as usize,
                 },
-                DashboardDistributionRow {
+                InventoryDistributionPoint {
                     label: "Stale".to_string(),
-                    value: compliance_rows.stale_nodes,
+                    value: compliance_rows.stale_nodes.max(0) as usize,
                 },
-            ]),
+            ],
             patch_age_buckets: map_buckets(patch_rows),
             top_outdated_software,
         })
@@ -1703,15 +1721,16 @@ impl InventoryRepository {
         sqlx::query(
             r#"
             INSERT INTO repository_version_catalog (
-                id, platform_family, distribution, package_manager, software_type,
+                id, platform_family, distribution, os_version_pattern, package_manager, software_type,
                 software_name, repository_source, latest_version, latest_release, source_kind,
                 observed_nodes, last_seen_at, created_at, updated_at
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
             "#,
         )
         .bind(&entry.id)
         .bind(&entry.platform_family)
         .bind(&entry.distribution)
+        .bind(&entry.os_version_pattern)
         .bind(&entry.package_manager)
         .bind(&entry.software_type)
         .bind(&entry.software_name)
@@ -1737,12 +1756,13 @@ impl InventoryRepository {
         sqlx::query(
             r#"
             INSERT INTO repository_version_catalog (
-                id, platform_family, distribution, package_manager, software_type,
+                id, platform_family, distribution, os_version_pattern, package_manager, software_type,
                 software_name, repository_source, latest_version, latest_release, source_kind,
                 observed_nodes, last_seen_at, created_at, updated_at
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
             ON CONFLICT(platform_family, distribution, package_manager, software_type,
-                        software_name, COALESCE(repository_source, ''), source_kind)
+                        software_name, COALESCE(repository_source, ''), source_kind,
+                        COALESCE(os_version_pattern, ''))
             DO UPDATE SET
                 latest_version = excluded.latest_version,
                 latest_release = excluded.latest_release,
@@ -1754,6 +1774,7 @@ impl InventoryRepository {
         .bind(&entry.id)
         .bind(&entry.platform_family)
         .bind(&entry.distribution)
+        .bind(&entry.os_version_pattern)
         .bind(&entry.package_manager)
         .bind(&entry.software_type)
         .bind(&entry.software_name)
@@ -1770,6 +1791,298 @@ impl InventoryRepository {
         .with_context(|| format!("Failed to upsert catalog entry '{}'", entry.software_name))?;
 
         Ok(())
+    }
+
+    // ── Group Update Schedules ──────────────────────────────────────
+
+    pub async fn list_group_update_schedules(
+        &self,
+        group_id: &str,
+    ) -> Result<Vec<GroupUpdateSchedule>> {
+        let rows = sqlx::query_as::<_, GroupUpdateScheduleRow>(
+            "SELECT * FROM group_update_schedules WHERE group_id = ?1 ORDER BY created_at DESC",
+        )
+        .bind(group_id)
+        .fetch_all(&self.pool)
+        .await
+        .context("Failed to list group update schedules")?;
+
+        Ok(rows.into_iter().map(Into::into).collect())
+    }
+
+    pub async fn get_group_update_schedule(
+        &self,
+        id: &str,
+    ) -> Result<Option<GroupUpdateSchedule>> {
+        let row = sqlx::query_as::<_, GroupUpdateScheduleRow>(
+            "SELECT * FROM group_update_schedules WHERE id = ?1",
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await
+        .context("Failed to fetch group update schedule")?;
+
+        Ok(row.map(Into::into))
+    }
+
+    pub async fn create_group_update_schedule(
+        &self,
+        group_id: &str,
+        request: &CreateGroupUpdateScheduleRequest,
+        created_by: &str,
+    ) -> Result<GroupUpdateSchedule> {
+        use crate::services::scheduler::{calculate_next_run, validate_cron_expression};
+
+        let id = Uuid::new_v4().to_string();
+        let now = Utc::now();
+
+        // Validate and compute next_run_at
+        let next_run_at = match request.schedule_type.as_str() {
+            "recurring" => {
+                let cron_expr = request
+                    .cron_expression
+                    .as_deref()
+                    .ok_or_else(|| anyhow::anyhow!("cron_expression is required for recurring schedules"))?;
+                validate_cron_expression(cron_expr)
+                    .map_err(|e| anyhow::anyhow!("{}", e))?;
+                calculate_next_run(cron_expr, "UTC")
+            }
+            "one_time" => request.scheduled_for,
+            _ => anyhow::bail!("Invalid schedule_type: must be 'one_time' or 'recurring'"),
+        };
+
+        let package_names_json = serde_json::to_string(&request.package_names)
+            .context("Failed to serialize package names")?;
+
+        sqlx::query(
+            r#"
+            INSERT INTO group_update_schedules (
+                id, group_id, name, description, schedule_type, cron_expression, scheduled_for,
+                operation_type, package_names_json, requires_approval,
+                maintenance_window_start, maintenance_window_end,
+                enabled, last_run_at, next_run_at, last_job_id,
+                created_by, created_at, updated_at
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, 1, NULL, ?13, NULL, ?14, ?15, ?16)
+            "#,
+        )
+        .bind(&id)
+        .bind(group_id)
+        .bind(&request.name)
+        .bind(&request.description)
+        .bind(&request.schedule_type)
+        .bind(&request.cron_expression)
+        .bind(request.scheduled_for.map(|ts| ts.to_rfc3339()))
+        .bind(request.operation_type.as_str())
+        .bind(&package_names_json)
+        .bind(request.requires_approval)
+        .bind(&request.maintenance_window_start)
+        .bind(&request.maintenance_window_end)
+        .bind(next_run_at.map(|ts| ts.to_rfc3339()))
+        .bind(created_by)
+        .bind(now.to_rfc3339())
+        .bind(now.to_rfc3339())
+        .execute(&self.pool)
+        .await
+        .context("Failed to create group update schedule")?;
+
+        self.get_group_update_schedule(&id)
+            .await?
+            .context("Schedule was created but could not be reloaded")
+    }
+
+    pub async fn update_group_update_schedule(
+        &self,
+        id: &str,
+        request: &UpdateGroupUpdateScheduleRequest,
+    ) -> Result<Option<GroupUpdateSchedule>> {
+        use crate::services::scheduler::{calculate_next_run, validate_cron_expression};
+
+        let existing = match self.get_group_update_schedule(id).await? {
+            Some(s) => s,
+            None => return Ok(None),
+        };
+
+        let now = Utc::now();
+        let name = request.name.as_deref().unwrap_or(&existing.name);
+        let description = request.description.as_deref().or(existing.description.as_deref());
+        let operation_type = request.operation_type.unwrap_or(existing.operation_type);
+        let requires_approval = request.requires_approval.unwrap_or(existing.requires_approval);
+        let enabled = request.enabled.unwrap_or(existing.enabled);
+        let mw_start = request
+            .maintenance_window_start
+            .as_deref()
+            .or(existing.maintenance_window_start.as_deref());
+        let mw_end = request
+            .maintenance_window_end
+            .as_deref()
+            .or(existing.maintenance_window_end.as_deref());
+        let package_names = request
+            .package_names
+            .as_ref()
+            .unwrap_or(&existing.package_names);
+        let package_names_json =
+            serde_json::to_string(package_names).context("Failed to serialize package names")?;
+
+        // Recompute next_run_at if schedule changed
+        let cron_expression = request
+            .cron_expression
+            .as_deref()
+            .or(existing.cron_expression.as_deref());
+        let scheduled_for = request.scheduled_for.or(existing.scheduled_for);
+
+        let next_run_at = if enabled {
+            match existing.schedule_type.as_str() {
+                "recurring" => {
+                    if let Some(cron_expr) = cron_expression {
+                        validate_cron_expression(cron_expr)
+                            .map_err(|e| anyhow::anyhow!("{}", e))?;
+                        calculate_next_run(cron_expr, "UTC")
+                    } else {
+                        existing.next_run_at
+                    }
+                }
+                "one_time" => scheduled_for,
+                _ => existing.next_run_at,
+            }
+        } else {
+            None
+        };
+
+        sqlx::query(
+            r#"
+            UPDATE group_update_schedules SET
+                name = ?1, description = ?2, cron_expression = ?3, scheduled_for = ?4,
+                operation_type = ?5, package_names_json = ?6, requires_approval = ?7,
+                maintenance_window_start = ?8, maintenance_window_end = ?9,
+                enabled = ?10, next_run_at = ?11, updated_at = ?12
+            WHERE id = ?13
+            "#,
+        )
+        .bind(name)
+        .bind(description)
+        .bind(cron_expression)
+        .bind(scheduled_for.map(|ts| ts.to_rfc3339()))
+        .bind(operation_type.as_str())
+        .bind(&package_names_json)
+        .bind(requires_approval)
+        .bind(mw_start)
+        .bind(mw_end)
+        .bind(enabled)
+        .bind(next_run_at.map(|ts| ts.to_rfc3339()))
+        .bind(now.to_rfc3339())
+        .bind(id)
+        .execute(&self.pool)
+        .await
+        .context("Failed to update group update schedule")?;
+
+        self.get_group_update_schedule(id).await
+    }
+
+    pub async fn delete_group_update_schedule(&self, id: &str) -> Result<bool> {
+        let result = sqlx::query("DELETE FROM group_update_schedules WHERE id = ?1")
+            .bind(id)
+            .execute(&self.pool)
+            .await
+            .context("Failed to delete group update schedule")?;
+        Ok(result.rows_affected() > 0)
+    }
+
+    pub async fn get_due_update_schedules(&self) -> Result<Vec<GroupUpdateSchedule>> {
+        let now = Utc::now().to_rfc3339();
+        let rows = sqlx::query_as::<_, GroupUpdateScheduleRow>(
+            r#"
+            SELECT * FROM group_update_schedules
+            WHERE enabled = 1 AND next_run_at IS NOT NULL AND next_run_at <= ?1
+            ORDER BY next_run_at ASC
+            "#,
+        )
+        .bind(&now)
+        .fetch_all(&self.pool)
+        .await
+        .context("Failed to fetch due update schedules")?;
+
+        Ok(rows.into_iter().map(Into::into).collect())
+    }
+
+    pub async fn update_schedule_after_run(
+        &self,
+        id: &str,
+        last_run_at: DateTime<Utc>,
+        next_run_at: Option<DateTime<Utc>>,
+        last_job_id: &str,
+        disable: bool,
+    ) -> Result<()> {
+        let now = Utc::now();
+        sqlx::query(
+            r#"
+            UPDATE group_update_schedules SET
+                last_run_at = ?1, next_run_at = ?2, last_job_id = ?3,
+                enabled = CASE WHEN ?4 THEN 0 ELSE enabled END,
+                updated_at = ?5
+            WHERE id = ?6
+            "#,
+        )
+        .bind(last_run_at.to_rfc3339())
+        .bind(next_run_at.map(|ts| ts.to_rfc3339()))
+        .bind(last_job_id)
+        .bind(disable)
+        .bind(now.to_rfc3339())
+        .bind(id)
+        .execute(&self.pool)
+        .await
+        .context("Failed to update schedule after run")?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, FromRow)]
+struct GroupUpdateScheduleRow {
+    id: String,
+    group_id: String,
+    name: String,
+    description: Option<String>,
+    schedule_type: String,
+    cron_expression: Option<String>,
+    scheduled_for: Option<String>,
+    operation_type: String,
+    package_names_json: String,
+    requires_approval: bool,
+    maintenance_window_start: Option<String>,
+    maintenance_window_end: Option<String>,
+    enabled: bool,
+    last_run_at: Option<String>,
+    next_run_at: Option<String>,
+    last_job_id: Option<String>,
+    created_by: String,
+    created_at: String,
+    updated_at: String,
+}
+
+impl From<GroupUpdateScheduleRow> for GroupUpdateSchedule {
+    fn from(row: GroupUpdateScheduleRow) -> Self {
+        Self {
+            id: row.id,
+            group_id: row.group_id,
+            name: row.name,
+            description: row.description,
+            schedule_type: row.schedule_type,
+            cron_expression: row.cron_expression,
+            scheduled_for: row.scheduled_for.as_deref().map(parse_timestamp_required),
+            operation_type: UpdateOperationType::from_str(&row.operation_type)
+                .unwrap_or(UpdateOperationType::SystemPatch),
+            package_names: serde_json::from_str(&row.package_names_json).unwrap_or_default(),
+            requires_approval: row.requires_approval,
+            maintenance_window_start: row.maintenance_window_start,
+            maintenance_window_end: row.maintenance_window_end,
+            enabled: row.enabled,
+            last_run_at: row.last_run_at.as_deref().map(parse_timestamp_required),
+            next_run_at: row.next_run_at.as_deref().map(parse_timestamp_required),
+            last_job_id: row.last_job_id,
+            created_by: row.created_by,
+            created_at: parse_timestamp_required(&row.created_at),
+            updated_at: parse_timestamp_required(&row.updated_at),
+        }
     }
 }
 
@@ -2071,6 +2384,7 @@ struct RepositoryVersionCatalogRow {
     id: String,
     platform_family: String,
     distribution: String,
+    os_version_pattern: Option<String>,
     package_manager: Option<String>,
     software_type: String,
     software_name: String,
@@ -2090,6 +2404,7 @@ impl From<RepositoryVersionCatalogRow> for RepositoryVersionCatalogEntry {
             id: row.id,
             platform_family: row.platform_family,
             distribution: row.distribution,
+            os_version_pattern: row.os_version_pattern,
             package_manager: row.package_manager,
             software_type: row.software_type,
             software_name: row.software_name,
@@ -2177,6 +2492,7 @@ impl From<FleetRepositoryConfigRow> for FleetRepositoryConfig {
 struct CatalogPackageObservationRow {
     os_family: String,
     distribution: String,
+    os_version_pattern: String,
     package_manager: Option<String>,
     name: String,
     repository_source: Option<String>,
@@ -2190,6 +2506,7 @@ struct CatalogPackageObservationRow {
 struct CatalogApplicationObservationRow {
     os_family: String,
     distribution: String,
+    os_version_pattern: String,
     package_manager: Option<String>,
     name: String,
     publisher: Option<String>,
@@ -2211,6 +2528,7 @@ struct HostPackageJoinedRow {
     certname: String,
     os_family: String,
     distribution: String,
+    os_version: String,
     package_manager: Option<String>,
     name: String,
     version: String,
@@ -2222,6 +2540,7 @@ struct HostPackageJoinedRow {
 struct HostPackageJoined {
     os_family: String,
     distribution: String,
+    os_version_pattern: Option<String>,
     package_manager: Option<String>,
     name: String,
     version: String,
@@ -2234,6 +2553,7 @@ struct HostApplicationJoinedRow {
     certname: String,
     os_family: String,
     distribution: String,
+    os_version: String,
     package_manager: Option<String>,
     name: String,
     version: String,
@@ -2245,6 +2565,7 @@ struct HostApplicationJoinedRow {
 struct HostApplicationJoined {
     os_family: String,
     distribution: String,
+    os_version_pattern: Option<String>,
     package_manager: Option<String>,
     name: String,
     version: String,
@@ -2352,7 +2673,7 @@ fn fold_package_catalog(
 ) -> Vec<RepositoryVersionCatalogEntry> {
     use std::collections::HashMap;
     let mut grouped: HashMap<
-        (String, String, Option<String>, String, Option<String>),
+        (String, String, String, Option<String>, String, Option<String>),
         CatalogPackageObservationRow,
     > = HashMap::new();
 
@@ -2360,6 +2681,7 @@ fn fold_package_catalog(
         let key = (
             row.os_family.clone(),
             row.distribution.clone(),
+            row.os_version_pattern.clone(),
             row.package_manager.clone(),
             row.name.clone(),
             row.repository_source.clone(),
@@ -2390,6 +2712,7 @@ fn fold_package_catalog(
             id: Uuid::new_v4().to_string(),
             platform_family: row.os_family,
             distribution: row.distribution,
+            os_version_pattern: Some(row.os_version_pattern),
             package_manager: row.package_manager,
             software_type: "package".to_string(),
             software_name: row.name,
@@ -2413,6 +2736,7 @@ fn fold_application_catalog(
         (
             String,
             String,
+            String,
             Option<String>,
             String,
             Option<String>,
@@ -2425,6 +2749,7 @@ fn fold_application_catalog(
         let key = (
             row.os_family.clone(),
             row.distribution.clone(),
+            row.os_version_pattern.clone(),
             row.package_manager.clone(),
             row.name.clone(),
             row.publisher.clone(),
@@ -2448,6 +2773,7 @@ fn fold_application_catalog(
             id: Uuid::new_v4().to_string(),
             platform_family: row.os_family,
             distribution: row.distribution,
+            os_version_pattern: Some(row.os_version_pattern),
             package_manager: row.package_manager,
             software_type: "application".to_string(),
             software_name: row.name,
@@ -2463,6 +2789,13 @@ fn fold_application_catalog(
         .collect()
 }
 
+fn extract_major_version(os_version: &str) -> String {
+    match os_version.find('.') {
+        Some(pos) => os_version[..pos].to_string(),
+        None => os_version.to_string(),
+    }
+}
+
 fn group_packages_by_host(
     rows: Vec<HostPackageJoinedRow>,
 ) -> std::collections::HashMap<String, Vec<HostPackageJoined>> {
@@ -2475,6 +2808,7 @@ fn group_packages_by_host(
             .push(HostPackageJoined {
                 os_family: row.os_family,
                 distribution: row.distribution,
+                os_version_pattern: Some(extract_major_version(&row.os_version)),
                 package_manager: row.package_manager,
                 name: row.name,
                 version: row.version,
@@ -2497,6 +2831,7 @@ fn group_applications_by_host(
             .push(HostApplicationJoined {
                 os_family: row.os_family,
                 distribution: row.distribution,
+                os_version_pattern: Some(extract_major_version(&row.os_version)),
                 package_manager: row.package_manager,
                 name: row.name,
                 version: row.version,
@@ -2524,13 +2859,14 @@ fn compare_packages(
     packages
         .iter()
         .filter_map(|pkg| {
-            // First try repo-checked: match by name + os_family + distribution + package_manager
+            // First try repo-checked: match by name + os_family + distribution + os_version_pattern + package_manager
             // (ignore repository_source since repo-checked uses repo_id, not vendor)
             let (catalog, source_kind) = repo_checked
                 .iter()
                 .find(|entry| {
                     entry.platform_family == pkg.os_family
                         && entry.distribution == pkg.distribution
+                        && entry.os_version_pattern == pkg.os_version_pattern
                         && entry.package_manager == pkg.package_manager
                         && entry.software_name == pkg.name
                 })
@@ -2542,6 +2878,7 @@ fn compare_packages(
                         .find(|entry| {
                             entry.platform_family == pkg.os_family
                                 && entry.distribution == pkg.distribution
+                                && entry.os_version_pattern == pkg.os_version_pattern
                                 && entry.package_manager == pkg.package_manager
                                 && entry.software_name == pkg.name
                                 && entry.repository_source == pkg.repository_source
@@ -2581,6 +2918,7 @@ fn compare_applications(
                 entry.software_type == "application"
                     && entry.platform_family == app.os_family
                     && entry.distribution == app.distribution
+                    && entry.os_version_pattern == app.os_version_pattern
                     && entry.package_manager == app.package_manager
                     && entry.software_name == app.name
                     && entry.repository_source == repo_source

--- a/src/main.rs
+++ b/src/main.rs
@@ -267,6 +267,11 @@ async fn main() -> Result<()> {
         None
     };
 
+    // Start Update Schedule scheduler (always enabled)
+    info!("Starting Update Schedule scheduler");
+    let _update_schedule_scheduler =
+        services::start_update_schedule_scheduler(db.clone());
+
     // Create application state
     let state = AppState {
         config: config.clone(),

--- a/src/models/inventory.rs
+++ b/src/models/inventory.rs
@@ -220,6 +220,7 @@ pub struct RepositoryVersionCatalogEntry {
     pub id: String,
     pub platform_family: String,
     pub distribution: String,
+    pub os_version_pattern: Option<String>,
     pub package_manager: Option<String>,
     pub software_type: String,
     pub software_name: String,
@@ -528,4 +529,59 @@ pub struct SubmitUpdateJobResultRequest {
     pub output: Option<String>,
     pub started_at: Option<DateTime<Utc>>,
     pub finished_at: Option<DateTime<Utc>>,
+}
+
+// ── Group Update Schedules ──────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GroupUpdateSchedule {
+    pub id: String,
+    pub group_id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub schedule_type: String,
+    pub cron_expression: Option<String>,
+    pub scheduled_for: Option<DateTime<Utc>>,
+    pub operation_type: UpdateOperationType,
+    pub package_names: Vec<String>,
+    pub requires_approval: bool,
+    pub maintenance_window_start: Option<String>,
+    pub maintenance_window_end: Option<String>,
+    pub enabled: bool,
+    pub last_run_at: Option<DateTime<Utc>>,
+    pub next_run_at: Option<DateTime<Utc>>,
+    pub last_job_id: Option<String>,
+    pub created_by: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateGroupUpdateScheduleRequest {
+    pub name: String,
+    pub description: Option<String>,
+    pub schedule_type: String,
+    pub cron_expression: Option<String>,
+    pub scheduled_for: Option<DateTime<Utc>>,
+    pub operation_type: UpdateOperationType,
+    #[serde(default)]
+    pub package_names: Vec<String>,
+    #[serde(default)]
+    pub requires_approval: bool,
+    pub maintenance_window_start: Option<String>,
+    pub maintenance_window_end: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateGroupUpdateScheduleRequest {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub cron_expression: Option<String>,
+    pub scheduled_for: Option<DateTime<Utc>>,
+    pub operation_type: Option<UpdateOperationType>,
+    pub package_names: Option<Vec<String>>,
+    pub requires_approval: Option<bool>,
+    pub maintenance_window_start: Option<String>,
+    pub maintenance_window_end: Option<String>,
+    pub enabled: Option<bool>,
 }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -26,6 +26,7 @@ pub mod rbac_db;
 pub mod reporting;
 pub mod saml;
 pub mod scheduler;
+pub mod update_schedule_scheduler;
 
 pub use alerting::AlertingService;
 pub use auth::AuthService;
@@ -58,3 +59,4 @@ pub use rbac_db::DbRbacService;
 pub use reporting::ReportingService;
 pub use saml::{SamlAssertion, SamlService};
 pub use scheduler::{ReportScheduler, ScheduleExecutionResult};
+pub use update_schedule_scheduler::{start_update_schedule_scheduler, UpdateScheduleSchedulerState};

--- a/src/services/repo_checker.rs
+++ b/src/services/repo_checker.rs
@@ -164,6 +164,7 @@ impl RepoCheckerService {
                 id: Uuid::new_v4().to_string(),
                 platform_family: config.os_family.clone(),
                 distribution: config.distribution.clone(),
+                os_version_pattern: Some(config.os_version_pattern.clone()),
                 package_manager: Some(config.package_manager.clone()),
                 software_type: "package".to_string(),
                 software_name: name.clone(),

--- a/src/services/update_schedule_scheduler.rs
+++ b/src/services/update_schedule_scheduler.rs
@@ -1,0 +1,200 @@
+//! Update schedule scheduler service.
+//!
+//! Background task that processes due group update schedules
+//! and creates UpdateJob records via the existing orchestration pipeline.
+
+use std::sync::Arc;
+
+use chrono::Utc;
+use sqlx::SqlitePool;
+use tokio::sync::RwLock;
+use tokio::time::{interval, Duration};
+use tracing::{error, info, warn};
+
+use crate::db::{repository::GroupRepository, InventoryRepository};
+use crate::services::scheduler::calculate_next_run;
+
+type DbPool = SqlitePool;
+
+#[derive(Clone)]
+pub struct UpdateScheduleSchedulerState {
+    running: Arc<RwLock<bool>>,
+    pool: DbPool,
+}
+
+impl UpdateScheduleSchedulerState {
+    pub fn new(pool: DbPool) -> Self {
+        Self {
+            running: Arc::new(RwLock::new(false)),
+            pool,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub async fn stop(&self) {
+        let mut running = self.running.write().await;
+        *running = false;
+        info!("Update schedule scheduler stop requested");
+    }
+}
+
+pub fn start_update_schedule_scheduler(pool: DbPool) -> UpdateScheduleSchedulerState {
+    let state = UpdateScheduleSchedulerState::new(pool);
+    let state_clone = state.clone();
+
+    tokio::spawn(async move {
+        let mut running = state_clone.running.write().await;
+        *running = true;
+        drop(running);
+    });
+
+    let task_state = state.clone();
+    tokio::spawn(async move {
+        schedule_check_task(task_state).await;
+    });
+
+    info!("Update schedule scheduler started");
+    state
+}
+
+async fn schedule_check_task(state: UpdateScheduleSchedulerState) {
+    // Wait a bit before first check to let the app fully start
+    tokio::time::sleep(Duration::from_secs(30)).await;
+
+    let mut tick = interval(Duration::from_secs(60));
+
+    loop {
+        tick.tick().await;
+
+        let running = state.running.read().await;
+        if !*running {
+            info!("Update schedule scheduler stopping");
+            break;
+        }
+        drop(running);
+
+        if let Err(e) = process_due_schedules(&state.pool).await {
+            error!("Update schedule check failed: {}", e);
+        }
+    }
+}
+
+async fn process_due_schedules(pool: &SqlitePool) -> anyhow::Result<()> {
+    let inv_repo = InventoryRepository::new(pool.clone());
+    let due_schedules = inv_repo.get_due_update_schedules().await?;
+
+    if due_schedules.is_empty() {
+        return Ok(());
+    }
+
+    info!("Processing {} due update schedules", due_schedules.len());
+    let group_repo = GroupRepository::new(pool);
+
+    for schedule in due_schedules {
+        let group_id = match uuid::Uuid::parse_str(&schedule.group_id) {
+            Ok(id) => id,
+            Err(e) => {
+                warn!(
+                    "Invalid group_id '{}' in schedule '{}': {}",
+                    schedule.group_id, schedule.id, e
+                );
+                continue;
+            }
+        };
+
+        let certnames = match group_repo.get_group_nodes(group_id).await {
+            Ok(nodes) => nodes,
+            Err(e) => {
+                warn!(
+                    "Failed to resolve nodes for group '{}' in schedule '{}': {}",
+                    schedule.group_id, schedule.id, e
+                );
+                continue;
+            }
+        };
+
+        if certnames.is_empty() {
+            warn!(
+                "No nodes found for group '{}' in schedule '{}', skipping",
+                schedule.group_id, schedule.id
+            );
+            // Still advance the schedule to prevent re-firing
+            let next_run = compute_next_run(&schedule);
+            let _ = inv_repo
+                .update_schedule_after_run(
+                    &schedule.id,
+                    Utc::now(),
+                    next_run,
+                    "",
+                    schedule.schedule_type == "one_time",
+                )
+                .await;
+            continue;
+        }
+
+        match inv_repo
+            .create_update_job(
+                schedule.operation_type,
+                &schedule.package_names,
+                Some(&schedule.group_id),
+                &certnames,
+                schedule.requires_approval,
+                None, // immediate execution
+                None,
+                None,
+                "update-schedule-scheduler",
+                Some(&format!("Auto-created from schedule '{}'", schedule.name)),
+            )
+            .await
+        {
+            Ok(job) => {
+                info!(
+                    "Created update job '{}' from schedule '{}' for {} nodes",
+                    job.id,
+                    schedule.name,
+                    certnames.len()
+                );
+
+                let next_run = compute_next_run(&schedule);
+                let is_one_time = schedule.schedule_type == "one_time";
+
+                if let Err(e) = inv_repo
+                    .update_schedule_after_run(
+                        &schedule.id,
+                        Utc::now(),
+                        next_run,
+                        &job.id,
+                        is_one_time,
+                    )
+                    .await
+                {
+                    error!(
+                        "Failed to update schedule '{}' after run: {}",
+                        schedule.id, e
+                    );
+                }
+            }
+            Err(e) => {
+                error!(
+                    "Failed to create update job from schedule '{}': {}",
+                    schedule.id, e
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn compute_next_run(
+    schedule: &crate::models::GroupUpdateSchedule,
+) -> Option<chrono::DateTime<Utc>> {
+    match schedule.schedule_type.as_str() {
+        "recurring" => schedule
+            .cron_expression
+            .as_deref()
+            .and_then(|cron| calculate_next_run(cron, "UTC")),
+        "one_time" => None, // one-time schedules don't have a next run
+        _ => None,
+    }
+}


### PR DESCRIPTION
## Changes

### Features
- **Group Update Schedules**: Add "Update Schedules" tab to Node Groups for managing one-time and recurring (cron-based) update tasks
- **Schedule Management**: Full CRUD API endpoints for group update schedules with enable/disable toggles and manual execution
- **Background Scheduler**: Add `update_schedule_scheduler` service to auto-create UpdateJobs when schedules are due
- **Frontend UI**: Complete schedule management interface with form validation, cron expression templates, and approval workflow options

### Fixes
- **Last Update Detection**: Properly detect last successful system update time from dnf/yum history, apt logs, and zypper history instead of always reporting "Never recorded"
- **OS Version Pattern**: Add `os_version_pattern` dimension to repository version catalog to prevent false-positive outdated detection when nodes run different OS major versions (e.g., el8 vs el9)
- **Compliance Chart**: Fix Update Compliance donut chart legend displaying "value" instead of category labels; always show all three compliance categories (Compliant/Outdated/Stale) even when zero

### Database
- Add `repository_version_catalog` migration with `os_version_pattern` column and updated unique index
- Create `group_update_schedules` table with fields for scheduling, approval workflows, and execution tracking

### Types & API
- Add `GroupUpdateSchedule`, `CreateGroupUpdateScheduleRequest`, and `UpdateGroupUpdateScheduleRequest` types
- Extend inventory facter to detect last update times across package managers
- Version bump: 0.30.2 → 0.31.0