### PR TITLE
fix(packaging): resolve local PuppetDB host for TLS; soften post-inst…

### DIFF
--- a/packaging/scripts/configure-openvox-webui.sh
+++ b/packaging/scripts/configure-openvox-webui.sh
@@ -195,11 +195,30 @@ detect_puppet() {
             local ssl_port=$(grep -E "^ssl-port\s*=" "$PUPPETDB_CONFDIR/conf.d/jetty.ini" 2>/dev/null | sed 's/.*=\s*//' | tr -d ' ')
             local plain_port=$(grep -E "^port\s*=" "$PUPPETDB_CONFDIR/conf.d/jetty.ini" 2>/dev/null | sed 's/.*=\s*//' | tr -d ' ')
 
-            [ -n "$ssl_port" ] && PUPPETDB_SSL_PORT="$ssl_port"
+            [ -n "$ssl_port" ] && PUPPETDB_SSL_PORT="$ssl_port" && PUPPETDB_PORT="$ssl_port"
             [ -n "$plain_port" ] && PUPPETDB_PLAINTEXT_PORT="$plain_port"
         fi
     else
         log_warn "PuppetDB not detected"
+    fi
+}
+
+# PuppetDB Jetty HTTPS certificates usually list the node's certname/FQDN in SAN,
+# not "localhost". Using localhost breaks TLS verification (curl HTTP 000, app ssl_verify).
+resolve_local_puppetdb_host() {
+    if [ "$HAS_PUPPETDB" != "true" ]; then
+        return 0
+    fi
+    local cn=""
+    if command -v puppet >/dev/null 2>&1; then
+        cn=$(puppet config print certname 2>/dev/null || true)
+    fi
+    if [ -z "$cn" ]; then
+        cn=$(hostname -f 2>/dev/null || hostname)
+    fi
+    if [ -n "$cn" ]; then
+        PUPPETDB_HOST="$cn"
+        log_info "Using PuppetDB host for TLS (matches typical server cert): $PUPPETDB_HOST"
     fi
 }
 
@@ -272,6 +291,8 @@ test_puppetdb_connection() {
 
 configure_puppetdb_access() {
     print_section "PuppetDB Configuration"
+
+    resolve_local_puppetdb_host
 
     if [ "$HAS_PUPPETDB" != "true" ]; then
         echo -e "${YELLOW}╔══════════════════════════════════════════════════════════════════╗${NC}"
@@ -381,7 +402,9 @@ configure_puppetdb_access() {
     if command -v curl >/dev/null 2>&1; then
         echo ""
         if ask_yes_no "Test PuppetDB connection now?" "y"; then
-            test_puppetdb_connection "$puppetdb_url" "$PUPPETDB_USE_SSL"
+            if ! test_puppetdb_connection "$puppetdb_url" "$PUPPETDB_USE_SSL"; then
+                log_warn "PuppetDB connection check failed; continuing install. Adjust puppetdb.url in $CONFIG_FILE if needed."
+            fi
         fi
     fi
 

--- a/puppet/CHANGELOG.md
+++ b/puppet/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add optional node group selection to drift detection baselines in create and edit modals
 
 ### Fixed
+- **Package post-install:** When PuppetDB is on the same host, the configure script now uses the agent `certname` (or FQDN) for the PuppetDB URL instead of `localhost`, so TLS matches the Jetty certificate. A failed post-install connection check no longer aborts `dpkg`/`apt` (warning only).
 - Fix login session persistence after browser refresh by waiting for auth store hydration before protected-route redirects
 - Fix access token expiration handling by adding automatic refresh-token retry for authenticated API requests
 - Fix intermittent WebUI freezes by hardening browser storage access, showing hydration loader state, and adding API request timeout defaults


### PR DESCRIPTION
## Description

When OpenVox WebUI is installed on the same host as PuppetDB, the post-install script used `https://localhost:…` for the PuppetDB URL and the optional `curl` check. The Jetty/PuppetDB server certificate often does not include `localhost` in SAN, so TLS verification fails (e.g. HTTP `000`). Because the script runs with `set -e`, a failed probe also aborted the configure step and left `dpkg`/`apt` in an error state.

Changes:

- If PuppetDB is detected locally, default `PUPPETDB_HOST` from `puppet config print certname`, or `hostname -f` / `hostname`, so the URL matches the usual server cert.
- When `jetty.ini` sets `ssl-port`, apply it to `PUPPETDB_PORT` as well (not only `PUPPETDB_SSL_PORT`).
- If the optional PuppetDB connection check fails, log a warning and continue so non-interactive installs complete.
- Note the packaging fix under `puppet/CHANGELOG.md` **[Unreleased]** → **Fixed**.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Tests (adding or updating tests)

## Related Issues

None Created

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

_(Adjust checkboxes after you run tests and confirm docs.)_

## Testing

- `bash -n packaging/scripts/configure-openvox-webui.sh`
- Manual / staging: install or run `configure-openvox-webui.sh --non-interactive` on a host with co-located PuppetDB whose cert does not include `localhost`; confirm `config.yaml` uses `https://<certname>:<port>/…` and that package configuration completes even if the probe warns.

## Screenshots (if applicable)

_N/A — packaging script and changelog only._
